### PR TITLE
CIF-933 - Generate and release Magento 2.3.2 GraphQL library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.adobe.commerce.cif</groupId>
     <artifactId>magento-graphql</artifactId>
-    <version>2.0.1-magento231-SNAPSHOT</version>
+    <version>3.0.0-magento232-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <name>Magento GraphQL data models and query builders</name>

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/AddConfigurableProductsToCartInput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/AddConfigurableProductsToCartInput.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.io.Serializable;
+import java.util.List;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+public class AddConfigurableProductsToCartInput implements Serializable {
+    private String cartId;
+
+    private List<ConfigurableProductCartItemInput> cartItems;
+
+    public AddConfigurableProductsToCartInput(String cartId, List<ConfigurableProductCartItemInput> cartItems) {
+        this.cartId = cartId;
+
+        this.cartItems = cartItems;
+    }
+
+    public String getCartId() {
+        return cartId;
+    }
+
+    public AddConfigurableProductsToCartInput setCartId(String cartId) {
+        this.cartId = cartId;
+        return this;
+    }
+
+    public List<ConfigurableProductCartItemInput> getCartItems() {
+        return cartItems;
+    }
+
+    public AddConfigurableProductsToCartInput setCartItems(List<ConfigurableProductCartItemInput> cartItems) {
+        this.cartItems = cartItems;
+        return this;
+    }
+
+    public void appendTo(StringBuilder _queryBuilder) {
+        String separator = "";
+        _queryBuilder.append('{');
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("cart_id:");
+        AbstractQuery.appendQuotedString(_queryBuilder, cartId.toString());
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("cart_items:");
+        _queryBuilder.append('[');
+        {
+            String listSeperator1 = "";
+            for (ConfigurableProductCartItemInput item1 : cartItems) {
+                _queryBuilder.append(listSeperator1);
+                listSeperator1 = ",";
+                item1.appendTo(_queryBuilder);
+            }
+        }
+        _queryBuilder.append(']');
+
+        _queryBuilder.append('}');
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/AddConfigurableProductsToCartOutput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/AddConfigurableProductsToCartOutput.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * 
+ */
+public class AddConfigurableProductsToCartOutput extends AbstractResponse<AddConfigurableProductsToCartOutput> {
+    public AddConfigurableProductsToCartOutput() {
+    }
+
+    public AddConfigurableProductsToCartOutput(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "cart": {
+                    responseData.put(key, new Cart(jsonAsObject(field.getValue(), key)));
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "AddConfigurableProductsToCartOutput";
+    }
+
+    public Cart getCart() {
+        return (Cart) get("cart");
+    }
+
+    public AddConfigurableProductsToCartOutput setCart(Cart arg) {
+        optimisticData.put(getKey("cart"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "cart": return true;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/AddConfigurableProductsToCartOutputQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/AddConfigurableProductsToCartOutputQuery.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * 
+ */
+public class AddConfigurableProductsToCartOutputQuery extends AbstractQuery<AddConfigurableProductsToCartOutputQuery> {
+    AddConfigurableProductsToCartOutputQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    public AddConfigurableProductsToCartOutputQuery cart(CartQueryDefinition queryDef) {
+        startField("cart");
+
+        _queryBuilder.append('{');
+        queryDef.define(new CartQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/AddConfigurableProductsToCartOutputQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/AddConfigurableProductsToCartOutputQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface AddConfigurableProductsToCartOutputQueryDefinition {
+    void define(AddConfigurableProductsToCartOutputQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/AddSimpleProductsToCartInput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/AddSimpleProductsToCartInput.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.io.Serializable;
+import java.util.List;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+public class AddSimpleProductsToCartInput implements Serializable {
+    private String cartId;
+
+    private List<SimpleProductCartItemInput> cartItems;
+
+    public AddSimpleProductsToCartInput(String cartId, List<SimpleProductCartItemInput> cartItems) {
+        this.cartId = cartId;
+
+        this.cartItems = cartItems;
+    }
+
+    public String getCartId() {
+        return cartId;
+    }
+
+    public AddSimpleProductsToCartInput setCartId(String cartId) {
+        this.cartId = cartId;
+        return this;
+    }
+
+    public List<SimpleProductCartItemInput> getCartItems() {
+        return cartItems;
+    }
+
+    public AddSimpleProductsToCartInput setCartItems(List<SimpleProductCartItemInput> cartItems) {
+        this.cartItems = cartItems;
+        return this;
+    }
+
+    public void appendTo(StringBuilder _queryBuilder) {
+        String separator = "";
+        _queryBuilder.append('{');
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("cart_id:");
+        AbstractQuery.appendQuotedString(_queryBuilder, cartId.toString());
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("cart_items:");
+        _queryBuilder.append('[');
+        {
+            String listSeperator1 = "";
+            for (SimpleProductCartItemInput item1 : cartItems) {
+                _queryBuilder.append(listSeperator1);
+                listSeperator1 = ",";
+                item1.appendTo(_queryBuilder);
+            }
+        }
+        _queryBuilder.append(']');
+
+        _queryBuilder.append('}');
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/AddSimpleProductsToCartOutput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/AddSimpleProductsToCartOutput.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * 
+ */
+public class AddSimpleProductsToCartOutput extends AbstractResponse<AddSimpleProductsToCartOutput> {
+    public AddSimpleProductsToCartOutput() {
+    }
+
+    public AddSimpleProductsToCartOutput(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "cart": {
+                    responseData.put(key, new Cart(jsonAsObject(field.getValue(), key)));
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "AddSimpleProductsToCartOutput";
+    }
+
+    public Cart getCart() {
+        return (Cart) get("cart");
+    }
+
+    public AddSimpleProductsToCartOutput setCart(Cart arg) {
+        optimisticData.put(getKey("cart"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "cart": return true;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/AddSimpleProductsToCartOutputQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/AddSimpleProductsToCartOutputQuery.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * 
+ */
+public class AddSimpleProductsToCartOutputQuery extends AbstractQuery<AddSimpleProductsToCartOutputQuery> {
+    AddSimpleProductsToCartOutputQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    public AddSimpleProductsToCartOutputQuery cart(CartQueryDefinition queryDef) {
+        startField("cart");
+
+        _queryBuilder.append('{');
+        queryDef.define(new CartQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/AddSimpleProductsToCartOutputQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/AddSimpleProductsToCartOutputQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface AddSimpleProductsToCartOutputQueryDefinition {
+    void define(AddSimpleProductsToCartOutputQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/AddVirtualProductsToCartInput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/AddVirtualProductsToCartInput.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.io.Serializable;
+import java.util.List;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+public class AddVirtualProductsToCartInput implements Serializable {
+    private String cartId;
+
+    private List<VirtualProductCartItemInput> cartItems;
+
+    public AddVirtualProductsToCartInput(String cartId, List<VirtualProductCartItemInput> cartItems) {
+        this.cartId = cartId;
+
+        this.cartItems = cartItems;
+    }
+
+    public String getCartId() {
+        return cartId;
+    }
+
+    public AddVirtualProductsToCartInput setCartId(String cartId) {
+        this.cartId = cartId;
+        return this;
+    }
+
+    public List<VirtualProductCartItemInput> getCartItems() {
+        return cartItems;
+    }
+
+    public AddVirtualProductsToCartInput setCartItems(List<VirtualProductCartItemInput> cartItems) {
+        this.cartItems = cartItems;
+        return this;
+    }
+
+    public void appendTo(StringBuilder _queryBuilder) {
+        String separator = "";
+        _queryBuilder.append('{');
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("cart_id:");
+        AbstractQuery.appendQuotedString(_queryBuilder, cartId.toString());
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("cart_items:");
+        _queryBuilder.append('[');
+        {
+            String listSeperator1 = "";
+            for (VirtualProductCartItemInput item1 : cartItems) {
+                _queryBuilder.append(listSeperator1);
+                listSeperator1 = ",";
+                item1.appendTo(_queryBuilder);
+            }
+        }
+        _queryBuilder.append(']');
+
+        _queryBuilder.append('}');
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/AddVirtualProductsToCartOutput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/AddVirtualProductsToCartOutput.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * 
+ */
+public class AddVirtualProductsToCartOutput extends AbstractResponse<AddVirtualProductsToCartOutput> {
+    public AddVirtualProductsToCartOutput() {
+    }
+
+    public AddVirtualProductsToCartOutput(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "cart": {
+                    responseData.put(key, new Cart(jsonAsObject(field.getValue(), key)));
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "AddVirtualProductsToCartOutput";
+    }
+
+    public Cart getCart() {
+        return (Cart) get("cart");
+    }
+
+    public AddVirtualProductsToCartOutput setCart(Cart arg) {
+        optimisticData.put(getKey("cart"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "cart": return true;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/AddVirtualProductsToCartOutputQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/AddVirtualProductsToCartOutputQuery.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * 
+ */
+public class AddVirtualProductsToCartOutputQuery extends AbstractQuery<AddVirtualProductsToCartOutputQuery> {
+    AddVirtualProductsToCartOutputQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    public AddVirtualProductsToCartOutputQuery cart(CartQueryDefinition queryDef) {
+        startField("cart");
+
+        _queryBuilder.append('{');
+        queryDef.define(new CartQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/AddVirtualProductsToCartOutputQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/AddVirtualProductsToCartOutputQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface AddVirtualProductsToCartOutputQueryDefinition {
+    void define(AddVirtualProductsToCartOutputQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/AppliedCoupon.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/AppliedCoupon.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * 
+ */
+public class AppliedCoupon extends AbstractResponse<AppliedCoupon> {
+    public AppliedCoupon() {
+    }
+
+    public AppliedCoupon(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "code": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "AppliedCoupon";
+    }
+
+    public String getCode() {
+        return (String) get("code");
+    }
+
+    public AppliedCoupon setCode(String arg) {
+        optimisticData.put(getKey("code"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "code": return false;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/AppliedCouponQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/AppliedCouponQuery.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * 
+ */
+public class AppliedCouponQuery extends AbstractQuery<AppliedCouponQuery> {
+    AppliedCouponQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    public AppliedCouponQuery code() {
+        startField("code");
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/AppliedCouponQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/AppliedCouponQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface AppliedCouponQueryDefinition {
+    void define(AppliedCouponQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/ApplyCouponToCartInput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/ApplyCouponToCartInput.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.io.Serializable;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+public class ApplyCouponToCartInput implements Serializable {
+    private String cartId;
+
+    private String couponCode;
+
+    public ApplyCouponToCartInput(String cartId, String couponCode) {
+        this.cartId = cartId;
+
+        this.couponCode = couponCode;
+    }
+
+    public String getCartId() {
+        return cartId;
+    }
+
+    public ApplyCouponToCartInput setCartId(String cartId) {
+        this.cartId = cartId;
+        return this;
+    }
+
+    public String getCouponCode() {
+        return couponCode;
+    }
+
+    public ApplyCouponToCartInput setCouponCode(String couponCode) {
+        this.couponCode = couponCode;
+        return this;
+    }
+
+    public void appendTo(StringBuilder _queryBuilder) {
+        String separator = "";
+        _queryBuilder.append('{');
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("cart_id:");
+        AbstractQuery.appendQuotedString(_queryBuilder, cartId.toString());
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("coupon_code:");
+        AbstractQuery.appendQuotedString(_queryBuilder, couponCode.toString());
+
+        _queryBuilder.append('}');
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/ApplyCouponToCartOutput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/ApplyCouponToCartOutput.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * 
+ */
+public class ApplyCouponToCartOutput extends AbstractResponse<ApplyCouponToCartOutput> {
+    public ApplyCouponToCartOutput() {
+    }
+
+    public ApplyCouponToCartOutput(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "cart": {
+                    responseData.put(key, new Cart(jsonAsObject(field.getValue(), key)));
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "ApplyCouponToCartOutput";
+    }
+
+    public Cart getCart() {
+        return (Cart) get("cart");
+    }
+
+    public ApplyCouponToCartOutput setCart(Cart arg) {
+        optimisticData.put(getKey("cart"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "cart": return true;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/ApplyCouponToCartOutputQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/ApplyCouponToCartOutputQuery.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * 
+ */
+public class ApplyCouponToCartOutputQuery extends AbstractQuery<ApplyCouponToCartOutputQuery> {
+    ApplyCouponToCartOutputQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    public ApplyCouponToCartOutputQuery cart(CartQueryDefinition queryDef) {
+        startField("cart");
+
+        _queryBuilder.append('{');
+        queryDef.define(new CartQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/ApplyCouponToCartOutputQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/ApplyCouponToCartOutputQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface ApplyCouponToCartOutputQueryDefinition {
+    void define(ApplyCouponToCartOutputQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/AvailablePaymentMethod.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/AvailablePaymentMethod.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * 
+ */
+public class AvailablePaymentMethod extends AbstractResponse<AvailablePaymentMethod> {
+    public AvailablePaymentMethod() {
+    }
+
+    public AvailablePaymentMethod(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "code": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+
+                    break;
+                }
+
+                case "title": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "AvailablePaymentMethod";
+    }
+
+    /**
+     * The payment method code
+     */
+
+    public String getCode() {
+        return (String) get("code");
+    }
+
+    public AvailablePaymentMethod setCode(String arg) {
+        optimisticData.put(getKey("code"), arg);
+        return this;
+    }
+
+    /**
+     * The payment method title.
+     */
+
+    public String getTitle() {
+        return (String) get("title");
+    }
+
+    public AvailablePaymentMethod setTitle(String arg) {
+        optimisticData.put(getKey("title"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "code": return false;
+
+            case "title": return false;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/AvailablePaymentMethodQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/AvailablePaymentMethodQuery.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * 
+ */
+public class AvailablePaymentMethodQuery extends AbstractQuery<AvailablePaymentMethodQuery> {
+    AvailablePaymentMethodQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    /**
+     * The payment method code
+     */
+    public AvailablePaymentMethodQuery code() {
+        startField("code");
+
+        return this;
+    }
+
+    /**
+     * The payment method title.
+     */
+    public AvailablePaymentMethodQuery title() {
+        startField("title");
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/AvailablePaymentMethodQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/AvailablePaymentMethodQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface AvailablePaymentMethodQueryDefinition {
+    void define(AvailablePaymentMethodQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/AvailableShippingMethod.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/AvailableShippingMethod.java
@@ -1,0 +1,259 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * 
+ */
+public class AvailableShippingMethod extends AbstractResponse<AvailableShippingMethod> {
+    public AvailableShippingMethod() {
+    }
+
+    public AvailableShippingMethod(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "amount": {
+                    responseData.put(key, new Money(jsonAsObject(field.getValue(), key)));
+
+                    break;
+                }
+
+                case "available": {
+                    responseData.put(key, jsonAsBoolean(field.getValue(), key));
+
+                    break;
+                }
+
+                case "base_amount": {
+                    Money optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = new Money(jsonAsObject(field.getValue(), key));
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "carrier_code": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+
+                    break;
+                }
+
+                case "carrier_title": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+
+                    break;
+                }
+
+                case "error_message": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "method_code": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "method_title": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "price_excl_tax": {
+                    responseData.put(key, new Money(jsonAsObject(field.getValue(), key)));
+
+                    break;
+                }
+
+                case "price_incl_tax": {
+                    responseData.put(key, new Money(jsonAsObject(field.getValue(), key)));
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "AvailableShippingMethod";
+    }
+
+    public Money getAmount() {
+        return (Money) get("amount");
+    }
+
+    public AvailableShippingMethod setAmount(Money arg) {
+        optimisticData.put(getKey("amount"), arg);
+        return this;
+    }
+
+    public Boolean getAvailable() {
+        return (Boolean) get("available");
+    }
+
+    public AvailableShippingMethod setAvailable(Boolean arg) {
+        optimisticData.put(getKey("available"), arg);
+        return this;
+    }
+
+    /**
+     * Could be null if method is not available
+     */
+
+    public Money getBaseAmount() {
+        return (Money) get("base_amount");
+    }
+
+    public AvailableShippingMethod setBaseAmount(Money arg) {
+        optimisticData.put(getKey("base_amount"), arg);
+        return this;
+    }
+
+    public String getCarrierCode() {
+        return (String) get("carrier_code");
+    }
+
+    public AvailableShippingMethod setCarrierCode(String arg) {
+        optimisticData.put(getKey("carrier_code"), arg);
+        return this;
+    }
+
+    public String getCarrierTitle() {
+        return (String) get("carrier_title");
+    }
+
+    public AvailableShippingMethod setCarrierTitle(String arg) {
+        optimisticData.put(getKey("carrier_title"), arg);
+        return this;
+    }
+
+    public String getErrorMessage() {
+        return (String) get("error_message");
+    }
+
+    public AvailableShippingMethod setErrorMessage(String arg) {
+        optimisticData.put(getKey("error_message"), arg);
+        return this;
+    }
+
+    /**
+     * Could be null if method is not available
+     */
+
+    public String getMethodCode() {
+        return (String) get("method_code");
+    }
+
+    public AvailableShippingMethod setMethodCode(String arg) {
+        optimisticData.put(getKey("method_code"), arg);
+        return this;
+    }
+
+    /**
+     * Could be null if method is not available
+     */
+
+    public String getMethodTitle() {
+        return (String) get("method_title");
+    }
+
+    public AvailableShippingMethod setMethodTitle(String arg) {
+        optimisticData.put(getKey("method_title"), arg);
+        return this;
+    }
+
+    public Money getPriceExclTax() {
+        return (Money) get("price_excl_tax");
+    }
+
+    public AvailableShippingMethod setPriceExclTax(Money arg) {
+        optimisticData.put(getKey("price_excl_tax"), arg);
+        return this;
+    }
+
+    public Money getPriceInclTax() {
+        return (Money) get("price_incl_tax");
+    }
+
+    public AvailableShippingMethod setPriceInclTax(Money arg) {
+        optimisticData.put(getKey("price_incl_tax"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "amount": return true;
+
+            case "available": return false;
+
+            case "base_amount": return true;
+
+            case "carrier_code": return false;
+
+            case "carrier_title": return false;
+
+            case "error_message": return false;
+
+            case "method_code": return false;
+
+            case "method_title": return false;
+
+            case "price_excl_tax": return true;
+
+            case "price_incl_tax": return true;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/AvailableShippingMethodQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/AvailableShippingMethodQuery.java
@@ -1,0 +1,111 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * 
+ */
+public class AvailableShippingMethodQuery extends AbstractQuery<AvailableShippingMethodQuery> {
+    AvailableShippingMethodQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    public AvailableShippingMethodQuery amount(MoneyQueryDefinition queryDef) {
+        startField("amount");
+
+        _queryBuilder.append('{');
+        queryDef.define(new MoneyQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public AvailableShippingMethodQuery available() {
+        startField("available");
+
+        return this;
+    }
+
+    /**
+     * Could be null if method is not available
+     */
+    public AvailableShippingMethodQuery baseAmount(MoneyQueryDefinition queryDef) {
+        startField("base_amount");
+
+        _queryBuilder.append('{');
+        queryDef.define(new MoneyQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public AvailableShippingMethodQuery carrierCode() {
+        startField("carrier_code");
+
+        return this;
+    }
+
+    public AvailableShippingMethodQuery carrierTitle() {
+        startField("carrier_title");
+
+        return this;
+    }
+
+    public AvailableShippingMethodQuery errorMessage() {
+        startField("error_message");
+
+        return this;
+    }
+
+    /**
+     * Could be null if method is not available
+     */
+    public AvailableShippingMethodQuery methodCode() {
+        startField("method_code");
+
+        return this;
+    }
+
+    /**
+     * Could be null if method is not available
+     */
+    public AvailableShippingMethodQuery methodTitle() {
+        startField("method_title");
+
+        return this;
+    }
+
+    public AvailableShippingMethodQuery priceExclTax(MoneyQueryDefinition queryDef) {
+        startField("price_excl_tax");
+
+        _queryBuilder.append('{');
+        queryDef.define(new MoneyQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public AvailableShippingMethodQuery priceInclTax(MoneyQueryDefinition queryDef) {
+        startField("price_incl_tax");
+
+        _queryBuilder.append('{');
+        queryDef.define(new MoneyQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/AvailableShippingMethodQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/AvailableShippingMethodQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface AvailableShippingMethodQueryDefinition {
+    void define(AvailableShippingMethodQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/BillingAddressInput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/BillingAddressInput.java
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.io.Serializable;
+
+import com.shopify.graphql.support.Input;
+
+public class BillingAddressInput implements Serializable {
+    private Input<CartAddressInput> address = Input.undefined();
+
+    private Input<Integer> customerAddressId = Input.undefined();
+
+    private Input<Boolean> useForShipping = Input.undefined();
+
+    public CartAddressInput getAddress() {
+        return address.getValue();
+    }
+
+    public Input<CartAddressInput> getAddressInput() {
+        return address;
+    }
+
+    public BillingAddressInput setAddress(CartAddressInput address) {
+        this.address = Input.optional(address);
+        return this;
+    }
+
+    public BillingAddressInput setAddressInput(Input<CartAddressInput> address) {
+        if (address == null) {
+            throw new IllegalArgumentException("Input can not be null");
+        }
+        this.address = address;
+        return this;
+    }
+
+    public Integer getCustomerAddressId() {
+        return customerAddressId.getValue();
+    }
+
+    public Input<Integer> getCustomerAddressIdInput() {
+        return customerAddressId;
+    }
+
+    public BillingAddressInput setCustomerAddressId(Integer customerAddressId) {
+        this.customerAddressId = Input.optional(customerAddressId);
+        return this;
+    }
+
+    public BillingAddressInput setCustomerAddressIdInput(Input<Integer> customerAddressId) {
+        if (customerAddressId == null) {
+            throw new IllegalArgumentException("Input can not be null");
+        }
+        this.customerAddressId = customerAddressId;
+        return this;
+    }
+
+    public Boolean getUseForShipping() {
+        return useForShipping.getValue();
+    }
+
+    public Input<Boolean> getUseForShippingInput() {
+        return useForShipping;
+    }
+
+    public BillingAddressInput setUseForShipping(Boolean useForShipping) {
+        this.useForShipping = Input.optional(useForShipping);
+        return this;
+    }
+
+    public BillingAddressInput setUseForShippingInput(Input<Boolean> useForShipping) {
+        if (useForShipping == null) {
+            throw new IllegalArgumentException("Input can not be null");
+        }
+        this.useForShipping = useForShipping;
+        return this;
+    }
+
+    public void appendTo(StringBuilder _queryBuilder) {
+        String separator = "";
+        _queryBuilder.append('{');
+
+        if (this.address.isDefined()) {
+            _queryBuilder.append(separator);
+            separator = ",";
+            _queryBuilder.append("address:");
+            if (address.getValue() != null) {
+                address.getValue().appendTo(_queryBuilder);
+            } else {
+                _queryBuilder.append("null");
+            }
+        }
+
+        if (this.customerAddressId.isDefined()) {
+            _queryBuilder.append(separator);
+            separator = ",";
+            _queryBuilder.append("customer_address_id:");
+            if (customerAddressId.getValue() != null) {
+                _queryBuilder.append(customerAddressId.getValue());
+            } else {
+                _queryBuilder.append("null");
+            }
+        }
+
+        if (this.useForShipping.isDefined()) {
+            _queryBuilder.append(separator);
+            separator = ",";
+            _queryBuilder.append("use_for_shipping:");
+            if (useForShipping.getValue() != null) {
+                _queryBuilder.append(useForShipping.getValue());
+            } else {
+                _queryBuilder.append("null");
+            }
+        }
+
+        _queryBuilder.append('}');
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/BillingCartAddress.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/BillingCartAddress.java
@@ -1,0 +1,289 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * 
+ */
+public class BillingCartAddress extends AbstractResponse<BillingCartAddress> implements CartAddressInterface {
+    public BillingCartAddress() {
+    }
+
+    public BillingCartAddress(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "city": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "company": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "country": {
+                    CartAddressCountry optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = new CartAddressCountry(jsonAsObject(field.getValue(), key));
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "customer_notes": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "firstname": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "lastname": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "postcode": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "region": {
+                    CartAddressRegion optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = new CartAddressRegion(jsonAsObject(field.getValue(), key));
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "street": {
+                    List<String> optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        List<String> list1 = new ArrayList<>();
+                        for (JsonElement element1 : jsonAsArray(field.getValue(), key)) {
+                            String optional2 = null;
+                            if (!element1.isJsonNull()) {
+                                optional2 = jsonAsString(element1, key);
+                            }
+
+                            list1.add(optional2);
+                        }
+
+                        optional1 = list1;
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "telephone": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "BillingCartAddress";
+    }
+
+    public String getCity() {
+        return (String) get("city");
+    }
+
+    public BillingCartAddress setCity(String arg) {
+        optimisticData.put(getKey("city"), arg);
+        return this;
+    }
+
+    public String getCompany() {
+        return (String) get("company");
+    }
+
+    public BillingCartAddress setCompany(String arg) {
+        optimisticData.put(getKey("company"), arg);
+        return this;
+    }
+
+    public CartAddressCountry getCountry() {
+        return (CartAddressCountry) get("country");
+    }
+
+    public BillingCartAddress setCountry(CartAddressCountry arg) {
+        optimisticData.put(getKey("country"), arg);
+        return this;
+    }
+
+    public String getCustomerNotes() {
+        return (String) get("customer_notes");
+    }
+
+    public BillingCartAddress setCustomerNotes(String arg) {
+        optimisticData.put(getKey("customer_notes"), arg);
+        return this;
+    }
+
+    public String getFirstname() {
+        return (String) get("firstname");
+    }
+
+    public BillingCartAddress setFirstname(String arg) {
+        optimisticData.put(getKey("firstname"), arg);
+        return this;
+    }
+
+    public String getLastname() {
+        return (String) get("lastname");
+    }
+
+    public BillingCartAddress setLastname(String arg) {
+        optimisticData.put(getKey("lastname"), arg);
+        return this;
+    }
+
+    public String getPostcode() {
+        return (String) get("postcode");
+    }
+
+    public BillingCartAddress setPostcode(String arg) {
+        optimisticData.put(getKey("postcode"), arg);
+        return this;
+    }
+
+    public CartAddressRegion getRegion() {
+        return (CartAddressRegion) get("region");
+    }
+
+    public BillingCartAddress setRegion(CartAddressRegion arg) {
+        optimisticData.put(getKey("region"), arg);
+        return this;
+    }
+
+    public List<String> getStreet() {
+        return (List<String>) get("street");
+    }
+
+    public BillingCartAddress setStreet(List<String> arg) {
+        optimisticData.put(getKey("street"), arg);
+        return this;
+    }
+
+    public String getTelephone() {
+        return (String) get("telephone");
+    }
+
+    public BillingCartAddress setTelephone(String arg) {
+        optimisticData.put(getKey("telephone"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "city": return false;
+
+            case "company": return false;
+
+            case "country": return true;
+
+            case "customer_notes": return false;
+
+            case "firstname": return false;
+
+            case "lastname": return false;
+
+            case "postcode": return false;
+
+            case "region": return true;
+
+            case "street": return false;
+
+            case "telephone": return false;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/BillingCartAddressQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/BillingCartAddressQuery.java
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * 
+ */
+public class BillingCartAddressQuery extends AbstractQuery<BillingCartAddressQuery> {
+    BillingCartAddressQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    public BillingCartAddressQuery city() {
+        startField("city");
+
+        return this;
+    }
+
+    public BillingCartAddressQuery company() {
+        startField("company");
+
+        return this;
+    }
+
+    public BillingCartAddressQuery country(CartAddressCountryQueryDefinition queryDef) {
+        startField("country");
+
+        _queryBuilder.append('{');
+        queryDef.define(new CartAddressCountryQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public BillingCartAddressQuery customerNotes() {
+        startField("customer_notes");
+
+        return this;
+    }
+
+    public BillingCartAddressQuery firstname() {
+        startField("firstname");
+
+        return this;
+    }
+
+    public BillingCartAddressQuery lastname() {
+        startField("lastname");
+
+        return this;
+    }
+
+    public BillingCartAddressQuery postcode() {
+        startField("postcode");
+
+        return this;
+    }
+
+    public BillingCartAddressQuery region(CartAddressRegionQueryDefinition queryDef) {
+        startField("region");
+
+        _queryBuilder.append('{');
+        queryDef.define(new CartAddressRegionQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public BillingCartAddressQuery street() {
+        startField("street");
+
+        return this;
+    }
+
+    public BillingCartAddressQuery telephone() {
+        startField("telephone");
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/BillingCartAddressQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/BillingCartAddressQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface BillingCartAddressQueryDefinition {
+    void define(BillingCartAddressQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/Cart.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/Cart.java
@@ -1,0 +1,259 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * 
+ */
+public class Cart extends AbstractResponse<Cart> {
+    public Cart() {
+    }
+
+    public Cart(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "applied_coupon": {
+                    AppliedCoupon optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = new AppliedCoupon(jsonAsObject(field.getValue(), key));
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "available_payment_methods": {
+                    List<AvailablePaymentMethod> optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        List<AvailablePaymentMethod> list1 = new ArrayList<>();
+                        for (JsonElement element1 : jsonAsArray(field.getValue(), key)) {
+                            AvailablePaymentMethod optional2 = null;
+                            if (!element1.isJsonNull()) {
+                                optional2 = new AvailablePaymentMethod(jsonAsObject(element1, key));
+                            }
+
+                            list1.add(optional2);
+                        }
+
+                        optional1 = list1;
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "billing_address": {
+                    responseData.put(key, new BillingCartAddress(jsonAsObject(field.getValue(), key)));
+
+                    break;
+                }
+
+                case "email": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "items": {
+                    List<CartItemInterface> optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        List<CartItemInterface> list1 = new ArrayList<>();
+                        for (JsonElement element1 : jsonAsArray(field.getValue(), key)) {
+                            CartItemInterface optional2 = null;
+                            if (!element1.isJsonNull()) {
+                                optional2 = UnknownCartItemInterface.create(jsonAsObject(element1, key));
+                            }
+
+                            list1.add(optional2);
+                        }
+
+                        optional1 = list1;
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "prices": {
+                    CartPrices optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = new CartPrices(jsonAsObject(field.getValue(), key));
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "selected_payment_method": {
+                    SelectedPaymentMethod optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = new SelectedPaymentMethod(jsonAsObject(field.getValue(), key));
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "shipping_addresses": {
+                    List<ShippingCartAddress> list1 = new ArrayList<>();
+                    for (JsonElement element1 : jsonAsArray(field.getValue(), key)) {
+                        ShippingCartAddress optional2 = null;
+                        if (!element1.isJsonNull()) {
+                            optional2 = new ShippingCartAddress(jsonAsObject(element1, key));
+                        }
+
+                        list1.add(optional2);
+                    }
+
+                    responseData.put(key, list1);
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "Cart";
+    }
+
+    public AppliedCoupon getAppliedCoupon() {
+        return (AppliedCoupon) get("applied_coupon");
+    }
+
+    public Cart setAppliedCoupon(AppliedCoupon arg) {
+        optimisticData.put(getKey("applied_coupon"), arg);
+        return this;
+    }
+
+    /**
+     * Available payment methods
+     */
+
+    public List<AvailablePaymentMethod> getAvailablePaymentMethods() {
+        return (List<AvailablePaymentMethod>) get("available_payment_methods");
+    }
+
+    public Cart setAvailablePaymentMethods(List<AvailablePaymentMethod> arg) {
+        optimisticData.put(getKey("available_payment_methods"), arg);
+        return this;
+    }
+
+    public BillingCartAddress getBillingAddress() {
+        return (BillingCartAddress) get("billing_address");
+    }
+
+    public Cart setBillingAddress(BillingCartAddress arg) {
+        optimisticData.put(getKey("billing_address"), arg);
+        return this;
+    }
+
+    public String getEmail() {
+        return (String) get("email");
+    }
+
+    public Cart setEmail(String arg) {
+        optimisticData.put(getKey("email"), arg);
+        return this;
+    }
+
+    public List<CartItemInterface> getItems() {
+        return (List<CartItemInterface>) get("items");
+    }
+
+    public Cart setItems(List<CartItemInterface> arg) {
+        optimisticData.put(getKey("items"), arg);
+        return this;
+    }
+
+    public CartPrices getPrices() {
+        return (CartPrices) get("prices");
+    }
+
+    public Cart setPrices(CartPrices arg) {
+        optimisticData.put(getKey("prices"), arg);
+        return this;
+    }
+
+    public SelectedPaymentMethod getSelectedPaymentMethod() {
+        return (SelectedPaymentMethod) get("selected_payment_method");
+    }
+
+    public Cart setSelectedPaymentMethod(SelectedPaymentMethod arg) {
+        optimisticData.put(getKey("selected_payment_method"), arg);
+        return this;
+    }
+
+    public List<ShippingCartAddress> getShippingAddresses() {
+        return (List<ShippingCartAddress>) get("shipping_addresses");
+    }
+
+    public Cart setShippingAddresses(List<ShippingCartAddress> arg) {
+        optimisticData.put(getKey("shipping_addresses"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "applied_coupon": return true;
+
+            case "available_payment_methods": return true;
+
+            case "billing_address": return true;
+
+            case "email": return false;
+
+            case "items": return false;
+
+            case "prices": return true;
+
+            case "selected_payment_method": return true;
+
+            case "shipping_addresses": return true;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CartAddressCountry.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CartAddressCountry.java
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * 
+ */
+public class CartAddressCountry extends AbstractResponse<CartAddressCountry> {
+    public CartAddressCountry() {
+    }
+
+    public CartAddressCountry(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "code": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "label": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "CartAddressCountry";
+    }
+
+    public String getCode() {
+        return (String) get("code");
+    }
+
+    public CartAddressCountry setCode(String arg) {
+        optimisticData.put(getKey("code"), arg);
+        return this;
+    }
+
+    public String getLabel() {
+        return (String) get("label");
+    }
+
+    public CartAddressCountry setLabel(String arg) {
+        optimisticData.put(getKey("label"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "code": return false;
+
+            case "label": return false;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CartAddressCountryQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CartAddressCountryQuery.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * 
+ */
+public class CartAddressCountryQuery extends AbstractQuery<CartAddressCountryQuery> {
+    CartAddressCountryQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    public CartAddressCountryQuery code() {
+        startField("code");
+
+        return this;
+    }
+
+    public CartAddressCountryQuery label() {
+        startField("label");
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CartAddressCountryQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CartAddressCountryQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface CartAddressCountryQueryDefinition {
+    void define(CartAddressCountryQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CartAddressInput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CartAddressInput.java
@@ -1,0 +1,269 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.io.Serializable;
+import java.util.List;
+
+import com.shopify.graphql.support.AbstractQuery;
+import com.shopify.graphql.support.Input;
+
+public class CartAddressInput implements Serializable {
+    private String city;
+
+    private String countryCode;
+
+    private String firstname;
+
+    private String lastname;
+
+    private boolean saveInAddressBook;
+
+    private List<String> street;
+
+    private String telephone;
+
+    private Input<String> company = Input.undefined();
+
+    private Input<String> postcode = Input.undefined();
+
+    private Input<String> region = Input.undefined();
+
+    public CartAddressInput(String city, String countryCode, String firstname, String lastname, boolean saveInAddressBook, List<String> street, String telephone) {
+        this.city = city;
+
+        this.countryCode = countryCode;
+
+        this.firstname = firstname;
+
+        this.lastname = lastname;
+
+        this.saveInAddressBook = saveInAddressBook;
+
+        this.street = street;
+
+        this.telephone = telephone;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public CartAddressInput setCity(String city) {
+        this.city = city;
+        return this;
+    }
+
+    public String getCountryCode() {
+        return countryCode;
+    }
+
+    public CartAddressInput setCountryCode(String countryCode) {
+        this.countryCode = countryCode;
+        return this;
+    }
+
+    public String getFirstname() {
+        return firstname;
+    }
+
+    public CartAddressInput setFirstname(String firstname) {
+        this.firstname = firstname;
+        return this;
+    }
+
+    public String getLastname() {
+        return lastname;
+    }
+
+    public CartAddressInput setLastname(String lastname) {
+        this.lastname = lastname;
+        return this;
+    }
+
+    public boolean getSaveInAddressBook() {
+        return saveInAddressBook;
+    }
+
+    public CartAddressInput setSaveInAddressBook(boolean saveInAddressBook) {
+        this.saveInAddressBook = saveInAddressBook;
+        return this;
+    }
+
+    public List<String> getStreet() {
+        return street;
+    }
+
+    public CartAddressInput setStreet(List<String> street) {
+        this.street = street;
+        return this;
+    }
+
+    public String getTelephone() {
+        return telephone;
+    }
+
+    public CartAddressInput setTelephone(String telephone) {
+        this.telephone = telephone;
+        return this;
+    }
+
+    public String getCompany() {
+        return company.getValue();
+    }
+
+    public Input<String> getCompanyInput() {
+        return company;
+    }
+
+    public CartAddressInput setCompany(String company) {
+        this.company = Input.optional(company);
+        return this;
+    }
+
+    public CartAddressInput setCompanyInput(Input<String> company) {
+        if (company == null) {
+            throw new IllegalArgumentException("Input can not be null");
+        }
+        this.company = company;
+        return this;
+    }
+
+    public String getPostcode() {
+        return postcode.getValue();
+    }
+
+    public Input<String> getPostcodeInput() {
+        return postcode;
+    }
+
+    public CartAddressInput setPostcode(String postcode) {
+        this.postcode = Input.optional(postcode);
+        return this;
+    }
+
+    public CartAddressInput setPostcodeInput(Input<String> postcode) {
+        if (postcode == null) {
+            throw new IllegalArgumentException("Input can not be null");
+        }
+        this.postcode = postcode;
+        return this;
+    }
+
+    public String getRegion() {
+        return region.getValue();
+    }
+
+    public Input<String> getRegionInput() {
+        return region;
+    }
+
+    public CartAddressInput setRegion(String region) {
+        this.region = Input.optional(region);
+        return this;
+    }
+
+    public CartAddressInput setRegionInput(Input<String> region) {
+        if (region == null) {
+            throw new IllegalArgumentException("Input can not be null");
+        }
+        this.region = region;
+        return this;
+    }
+
+    public void appendTo(StringBuilder _queryBuilder) {
+        String separator = "";
+        _queryBuilder.append('{');
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("city:");
+        AbstractQuery.appendQuotedString(_queryBuilder, city.toString());
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("country_code:");
+        AbstractQuery.appendQuotedString(_queryBuilder, countryCode.toString());
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("firstname:");
+        AbstractQuery.appendQuotedString(_queryBuilder, firstname.toString());
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("lastname:");
+        AbstractQuery.appendQuotedString(_queryBuilder, lastname.toString());
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("save_in_address_book:");
+        _queryBuilder.append(saveInAddressBook);
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("street:");
+        _queryBuilder.append('[');
+        {
+            String listSeperator1 = "";
+            for (String item1 : street) {
+                _queryBuilder.append(listSeperator1);
+                listSeperator1 = ",";
+                AbstractQuery.appendQuotedString(_queryBuilder, item1.toString());
+            }
+        }
+        _queryBuilder.append(']');
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("telephone:");
+        AbstractQuery.appendQuotedString(_queryBuilder, telephone.toString());
+
+        if (this.company.isDefined()) {
+            _queryBuilder.append(separator);
+            separator = ",";
+            _queryBuilder.append("company:");
+            if (company.getValue() != null) {
+                AbstractQuery.appendQuotedString(_queryBuilder, company.getValue().toString());
+            } else {
+                _queryBuilder.append("null");
+            }
+        }
+
+        if (this.postcode.isDefined()) {
+            _queryBuilder.append(separator);
+            separator = ",";
+            _queryBuilder.append("postcode:");
+            if (postcode.getValue() != null) {
+                AbstractQuery.appendQuotedString(_queryBuilder, postcode.getValue().toString());
+            } else {
+                _queryBuilder.append("null");
+            }
+        }
+
+        if (this.region.isDefined()) {
+            _queryBuilder.append(separator);
+            separator = ",";
+            _queryBuilder.append("region:");
+            if (region.getValue() != null) {
+                AbstractQuery.appendQuotedString(_queryBuilder, region.getValue().toString());
+            } else {
+                _queryBuilder.append("null");
+            }
+        }
+
+        _queryBuilder.append('}');
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CartAddressInterface.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CartAddressInterface.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.List;
+
+/**
+ * 
+ */
+
+public interface CartAddressInterface {
+    String getGraphQlTypeName();
+
+    String getCity();
+
+    String getCompany();
+
+    CartAddressCountry getCountry();
+
+    String getCustomerNotes();
+
+    String getFirstname();
+
+    String getLastname();
+
+    String getPostcode();
+
+    CartAddressRegion getRegion();
+
+    List<String> getStreet();
+
+    String getTelephone();
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CartAddressInterfaceQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CartAddressInterfaceQuery.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * 
+ */
+public class CartAddressInterfaceQuery extends AbstractQuery<CartAddressInterfaceQuery> {
+    CartAddressInterfaceQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+
+        startField("__typename");
+    }
+
+    public CartAddressInterfaceQuery city() {
+        startField("city");
+
+        return this;
+    }
+
+    public CartAddressInterfaceQuery company() {
+        startField("company");
+
+        return this;
+    }
+
+    public CartAddressInterfaceQuery country(CartAddressCountryQueryDefinition queryDef) {
+        startField("country");
+
+        _queryBuilder.append('{');
+        queryDef.define(new CartAddressCountryQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public CartAddressInterfaceQuery customerNotes() {
+        startField("customer_notes");
+
+        return this;
+    }
+
+    public CartAddressInterfaceQuery firstname() {
+        startField("firstname");
+
+        return this;
+    }
+
+    public CartAddressInterfaceQuery lastname() {
+        startField("lastname");
+
+        return this;
+    }
+
+    public CartAddressInterfaceQuery postcode() {
+        startField("postcode");
+
+        return this;
+    }
+
+    public CartAddressInterfaceQuery region(CartAddressRegionQueryDefinition queryDef) {
+        startField("region");
+
+        _queryBuilder.append('{');
+        queryDef.define(new CartAddressRegionQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public CartAddressInterfaceQuery street() {
+        startField("street");
+
+        return this;
+    }
+
+    public CartAddressInterfaceQuery telephone() {
+        startField("telephone");
+
+        return this;
+    }
+
+    public CartAddressInterfaceQuery onBillingCartAddress(BillingCartAddressQueryDefinition queryDef) {
+        startInlineFragment("BillingCartAddress");
+        queryDef.define(new BillingCartAddressQuery(_queryBuilder));
+        _queryBuilder.append('}');
+        return this;
+    }
+
+    public CartAddressInterfaceQuery onShippingCartAddress(ShippingCartAddressQueryDefinition queryDef) {
+        startInlineFragment("ShippingCartAddress");
+        queryDef.define(new ShippingCartAddressQuery(_queryBuilder));
+        _queryBuilder.append('}');
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CartAddressInterfaceQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CartAddressInterfaceQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface CartAddressInterfaceQueryDefinition {
+    void define(CartAddressInterfaceQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CartAddressRegion.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CartAddressRegion.java
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * 
+ */
+public class CartAddressRegion extends AbstractResponse<CartAddressRegion> {
+    public CartAddressRegion() {
+    }
+
+    public CartAddressRegion(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "code": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "label": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "CartAddressRegion";
+    }
+
+    public String getCode() {
+        return (String) get("code");
+    }
+
+    public CartAddressRegion setCode(String arg) {
+        optimisticData.put(getKey("code"), arg);
+        return this;
+    }
+
+    public String getLabel() {
+        return (String) get("label");
+    }
+
+    public CartAddressRegion setLabel(String arg) {
+        optimisticData.put(getKey("label"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "code": return false;
+
+            case "label": return false;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CartAddressRegionQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CartAddressRegionQuery.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * 
+ */
+public class CartAddressRegionQuery extends AbstractQuery<CartAddressRegionQuery> {
+    CartAddressRegionQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    public CartAddressRegionQuery code() {
+        startField("code");
+
+        return this;
+    }
+
+    public CartAddressRegionQuery label() {
+        startField("label");
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CartAddressRegionQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CartAddressRegionQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface CartAddressRegionQueryDefinition {
+    void define(CartAddressRegionQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CartItemInput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CartItemInput.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.io.Serializable;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+public class CartItemInput implements Serializable {
+    private double quantity;
+
+    private String sku;
+
+    public CartItemInput(double quantity, String sku) {
+        this.quantity = quantity;
+
+        this.sku = sku;
+    }
+
+    public double getQuantity() {
+        return quantity;
+    }
+
+    public CartItemInput setQuantity(double quantity) {
+        this.quantity = quantity;
+        return this;
+    }
+
+    public String getSku() {
+        return sku;
+    }
+
+    public CartItemInput setSku(String sku) {
+        this.sku = sku;
+        return this;
+    }
+
+    public void appendTo(StringBuilder _queryBuilder) {
+        String separator = "";
+        _queryBuilder.append('{');
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("quantity:");
+        _queryBuilder.append(quantity);
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("sku:");
+        AbstractQuery.appendQuotedString(_queryBuilder, sku.toString());
+
+        _queryBuilder.append('}');
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CartItemInterface.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CartItemInterface.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+/**
+ * 
+ */
+
+public interface CartItemInterface {
+    String getGraphQlTypeName();
+
+    String getId();
+
+    ProductInterface getProduct();
+
+    Double getQuantity();
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CartItemInterfaceQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CartItemInterfaceQuery.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * 
+ */
+public class CartItemInterfaceQuery extends AbstractQuery<CartItemInterfaceQuery> {
+    CartItemInterfaceQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+
+        startField("__typename");
+    }
+
+    public CartItemInterfaceQuery id() {
+        startField("id");
+
+        return this;
+    }
+
+    public CartItemInterfaceQuery product(ProductInterfaceQueryDefinition queryDef) {
+        startField("product");
+
+        _queryBuilder.append('{');
+        queryDef.define(new ProductInterfaceQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public CartItemInterfaceQuery quantity() {
+        startField("quantity");
+
+        return this;
+    }
+
+    public CartItemInterfaceQuery onConfigurableCartItem(ConfigurableCartItemQueryDefinition queryDef) {
+        startInlineFragment("ConfigurableCartItem");
+        queryDef.define(new ConfigurableCartItemQuery(_queryBuilder));
+        _queryBuilder.append('}');
+        return this;
+    }
+
+    public CartItemInterfaceQuery onSimpleCartItem(SimpleCartItemQueryDefinition queryDef) {
+        startInlineFragment("SimpleCartItem");
+        queryDef.define(new SimpleCartItemQuery(_queryBuilder));
+        _queryBuilder.append('}');
+        return this;
+    }
+
+    public CartItemInterfaceQuery onVirtualCartItem(VirtualCartItemQueryDefinition queryDef) {
+        startInlineFragment("VirtualCartItem");
+        queryDef.define(new VirtualCartItemQuery(_queryBuilder));
+        _queryBuilder.append('}');
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CartItemInterfaceQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CartItemInterfaceQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface CartItemInterfaceQueryDefinition {
+    void define(CartItemInterfaceQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CartItemQuantity.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CartItemQuantity.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * 
+ */
+public class CartItemQuantity extends AbstractResponse<CartItemQuantity> {
+    public CartItemQuantity() {
+    }
+
+    public CartItemQuantity(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "cart_item_id": {
+                    responseData.put(key, jsonAsInteger(field.getValue(), key));
+
+                    break;
+                }
+
+                case "quantity": {
+                    responseData.put(key, jsonAsDouble(field.getValue(), key));
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "CartItemQuantity";
+    }
+
+    public Integer getCartItemId() {
+        return (Integer) get("cart_item_id");
+    }
+
+    public CartItemQuantity setCartItemId(Integer arg) {
+        optimisticData.put(getKey("cart_item_id"), arg);
+        return this;
+    }
+
+    public Double getQuantity() {
+        return (Double) get("quantity");
+    }
+
+    public CartItemQuantity setQuantity(Double arg) {
+        optimisticData.put(getKey("quantity"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "cart_item_id": return false;
+
+            case "quantity": return false;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CartItemQuantityQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CartItemQuantityQuery.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * 
+ */
+public class CartItemQuantityQuery extends AbstractQuery<CartItemQuantityQuery> {
+    CartItemQuantityQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    public CartItemQuantityQuery cartItemId() {
+        startField("cart_item_id");
+
+        return this;
+    }
+
+    public CartItemQuantityQuery quantity() {
+        startField("quantity");
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CartItemQuantityQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CartItemQuantityQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface CartItemQuantityQueryDefinition {
+    void define(CartItemQuantityQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CartItemSelectedOptionValuePrice.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CartItemSelectedOptionValuePrice.java
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * 
+ */
+public class CartItemSelectedOptionValuePrice extends AbstractResponse<CartItemSelectedOptionValuePrice> {
+    public CartItemSelectedOptionValuePrice() {
+    }
+
+    public CartItemSelectedOptionValuePrice(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "type": {
+                    responseData.put(key, PriceTypeEnum.fromGraphQl(jsonAsString(field.getValue(), key)));
+
+                    break;
+                }
+
+                case "units": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+
+                    break;
+                }
+
+                case "value": {
+                    responseData.put(key, jsonAsDouble(field.getValue(), key));
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "CartItemSelectedOptionValuePrice";
+    }
+
+    public PriceTypeEnum getType() {
+        return (PriceTypeEnum) get("type");
+    }
+
+    public CartItemSelectedOptionValuePrice setType(PriceTypeEnum arg) {
+        optimisticData.put(getKey("type"), arg);
+        return this;
+    }
+
+    public String getUnits() {
+        return (String) get("units");
+    }
+
+    public CartItemSelectedOptionValuePrice setUnits(String arg) {
+        optimisticData.put(getKey("units"), arg);
+        return this;
+    }
+
+    public Double getValue() {
+        return (Double) get("value");
+    }
+
+    public CartItemSelectedOptionValuePrice setValue(Double arg) {
+        optimisticData.put(getKey("value"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "type": return false;
+
+            case "units": return false;
+
+            case "value": return false;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CartItemSelectedOptionValuePriceQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CartItemSelectedOptionValuePriceQuery.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * 
+ */
+public class CartItemSelectedOptionValuePriceQuery extends AbstractQuery<CartItemSelectedOptionValuePriceQuery> {
+    CartItemSelectedOptionValuePriceQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    public CartItemSelectedOptionValuePriceQuery type() {
+        startField("type");
+
+        return this;
+    }
+
+    public CartItemSelectedOptionValuePriceQuery units() {
+        startField("units");
+
+        return this;
+    }
+
+    public CartItemSelectedOptionValuePriceQuery value() {
+        startField("value");
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CartItemSelectedOptionValuePriceQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CartItemSelectedOptionValuePriceQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface CartItemSelectedOptionValuePriceQueryDefinition {
+    void define(CartItemSelectedOptionValuePriceQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CartItemUpdateInput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CartItemUpdateInput.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.io.Serializable;
+
+public class CartItemUpdateInput implements Serializable {
+    private int cartItemId;
+
+    private double quantity;
+
+    public CartItemUpdateInput(int cartItemId, double quantity) {
+        this.cartItemId = cartItemId;
+
+        this.quantity = quantity;
+    }
+
+    public int getCartItemId() {
+        return cartItemId;
+    }
+
+    public CartItemUpdateInput setCartItemId(int cartItemId) {
+        this.cartItemId = cartItemId;
+        return this;
+    }
+
+    public double getQuantity() {
+        return quantity;
+    }
+
+    public CartItemUpdateInput setQuantity(double quantity) {
+        this.quantity = quantity;
+        return this;
+    }
+
+    public void appendTo(StringBuilder _queryBuilder) {
+        String separator = "";
+        _queryBuilder.append('{');
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("cart_item_id:");
+        _queryBuilder.append(cartItemId);
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("quantity:");
+        _queryBuilder.append(quantity);
+
+        _queryBuilder.append('}');
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CartPrices.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CartPrices.java
@@ -1,0 +1,179 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * 
+ */
+public class CartPrices extends AbstractResponse<CartPrices> {
+    public CartPrices() {
+    }
+
+    public CartPrices(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "applied_taxes": {
+                    List<CartTaxItem> optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        List<CartTaxItem> list1 = new ArrayList<>();
+                        for (JsonElement element1 : jsonAsArray(field.getValue(), key)) {
+                            CartTaxItem optional2 = null;
+                            if (!element1.isJsonNull()) {
+                                optional2 = new CartTaxItem(jsonAsObject(element1, key));
+                            }
+
+                            list1.add(optional2);
+                        }
+
+                        optional1 = list1;
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "grand_total": {
+                    Money optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = new Money(jsonAsObject(field.getValue(), key));
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "subtotal_excluding_tax": {
+                    Money optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = new Money(jsonAsObject(field.getValue(), key));
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "subtotal_including_tax": {
+                    Money optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = new Money(jsonAsObject(field.getValue(), key));
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "subtotal_with_discount_excluding_tax": {
+                    Money optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = new Money(jsonAsObject(field.getValue(), key));
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "CartPrices";
+    }
+
+    public List<CartTaxItem> getAppliedTaxes() {
+        return (List<CartTaxItem>) get("applied_taxes");
+    }
+
+    public CartPrices setAppliedTaxes(List<CartTaxItem> arg) {
+        optimisticData.put(getKey("applied_taxes"), arg);
+        return this;
+    }
+
+    public Money getGrandTotal() {
+        return (Money) get("grand_total");
+    }
+
+    public CartPrices setGrandTotal(Money arg) {
+        optimisticData.put(getKey("grand_total"), arg);
+        return this;
+    }
+
+    public Money getSubtotalExcludingTax() {
+        return (Money) get("subtotal_excluding_tax");
+    }
+
+    public CartPrices setSubtotalExcludingTax(Money arg) {
+        optimisticData.put(getKey("subtotal_excluding_tax"), arg);
+        return this;
+    }
+
+    public Money getSubtotalIncludingTax() {
+        return (Money) get("subtotal_including_tax");
+    }
+
+    public CartPrices setSubtotalIncludingTax(Money arg) {
+        optimisticData.put(getKey("subtotal_including_tax"), arg);
+        return this;
+    }
+
+    public Money getSubtotalWithDiscountExcludingTax() {
+        return (Money) get("subtotal_with_discount_excluding_tax");
+    }
+
+    public CartPrices setSubtotalWithDiscountExcludingTax(Money arg) {
+        optimisticData.put(getKey("subtotal_with_discount_excluding_tax"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "applied_taxes": return true;
+
+            case "grand_total": return true;
+
+            case "subtotal_excluding_tax": return true;
+
+            case "subtotal_including_tax": return true;
+
+            case "subtotal_with_discount_excluding_tax": return true;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CartPricesQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CartPricesQuery.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * 
+ */
+public class CartPricesQuery extends AbstractQuery<CartPricesQuery> {
+    CartPricesQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    public CartPricesQuery appliedTaxes(CartTaxItemQueryDefinition queryDef) {
+        startField("applied_taxes");
+
+        _queryBuilder.append('{');
+        queryDef.define(new CartTaxItemQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public CartPricesQuery grandTotal(MoneyQueryDefinition queryDef) {
+        startField("grand_total");
+
+        _queryBuilder.append('{');
+        queryDef.define(new MoneyQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public CartPricesQuery subtotalExcludingTax(MoneyQueryDefinition queryDef) {
+        startField("subtotal_excluding_tax");
+
+        _queryBuilder.append('{');
+        queryDef.define(new MoneyQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public CartPricesQuery subtotalIncludingTax(MoneyQueryDefinition queryDef) {
+        startField("subtotal_including_tax");
+
+        _queryBuilder.append('{');
+        queryDef.define(new MoneyQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public CartPricesQuery subtotalWithDiscountExcludingTax(MoneyQueryDefinition queryDef) {
+        startField("subtotal_with_discount_excluding_tax");
+
+        _queryBuilder.append('{');
+        queryDef.define(new MoneyQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CartPricesQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CartPricesQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface CartPricesQueryDefinition {
+    void define(CartPricesQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CartQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CartQuery.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * 
+ */
+public class CartQuery extends AbstractQuery<CartQuery> {
+    CartQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    public CartQuery appliedCoupon(AppliedCouponQueryDefinition queryDef) {
+        startField("applied_coupon");
+
+        _queryBuilder.append('{');
+        queryDef.define(new AppliedCouponQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    /**
+     * Available payment methods
+     */
+    public CartQuery availablePaymentMethods(AvailablePaymentMethodQueryDefinition queryDef) {
+        startField("available_payment_methods");
+
+        _queryBuilder.append('{');
+        queryDef.define(new AvailablePaymentMethodQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public CartQuery billingAddress(BillingCartAddressQueryDefinition queryDef) {
+        startField("billing_address");
+
+        _queryBuilder.append('{');
+        queryDef.define(new BillingCartAddressQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public CartQuery email() {
+        startField("email");
+
+        return this;
+    }
+
+    public CartQuery items(CartItemInterfaceQueryDefinition queryDef) {
+        startField("items");
+
+        _queryBuilder.append('{');
+        queryDef.define(new CartItemInterfaceQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public CartQuery prices(CartPricesQueryDefinition queryDef) {
+        startField("prices");
+
+        _queryBuilder.append('{');
+        queryDef.define(new CartPricesQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public CartQuery selectedPaymentMethod(SelectedPaymentMethodQueryDefinition queryDef) {
+        startField("selected_payment_method");
+
+        _queryBuilder.append('{');
+        queryDef.define(new SelectedPaymentMethodQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public CartQuery shippingAddresses(ShippingCartAddressQueryDefinition queryDef) {
+        startField("shipping_addresses");
+
+        _queryBuilder.append('{');
+        queryDef.define(new ShippingCartAddressQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CartQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CartQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface CartQueryDefinition {
+    void define(CartQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CartTaxItem.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CartTaxItem.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * 
+ */
+public class CartTaxItem extends AbstractResponse<CartTaxItem> {
+    public CartTaxItem() {
+    }
+
+    public CartTaxItem(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "amount": {
+                    responseData.put(key, new Money(jsonAsObject(field.getValue(), key)));
+
+                    break;
+                }
+
+                case "label": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "CartTaxItem";
+    }
+
+    public Money getAmount() {
+        return (Money) get("amount");
+    }
+
+    public CartTaxItem setAmount(Money arg) {
+        optimisticData.put(getKey("amount"), arg);
+        return this;
+    }
+
+    public String getLabel() {
+        return (String) get("label");
+    }
+
+    public CartTaxItem setLabel(String arg) {
+        optimisticData.put(getKey("label"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "amount": return true;
+
+            case "label": return false;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CartTaxItemQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CartTaxItemQuery.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * 
+ */
+public class CartTaxItemQuery extends AbstractQuery<CartTaxItemQuery> {
+    CartTaxItemQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    public CartTaxItemQuery amount(MoneyQueryDefinition queryDef) {
+        startField("amount");
+
+        _queryBuilder.append('{');
+        queryDef.define(new MoneyQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public CartTaxItemQuery label() {
+        startField("label");
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CartTaxItemQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CartTaxItemQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface CartTaxItemQueryDefinition {
+    void define(CartTaxItemQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/ConfigurableCartItem.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/ConfigurableCartItem.java
@@ -1,0 +1,164 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * 
+ */
+public class ConfigurableCartItem extends AbstractResponse<ConfigurableCartItem> implements CartItemInterface {
+    public ConfigurableCartItem() {
+    }
+
+    public ConfigurableCartItem(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "configurable_options": {
+                    List<SelectedConfigurableOption> list1 = new ArrayList<>();
+                    for (JsonElement element1 : jsonAsArray(field.getValue(), key)) {
+                        SelectedConfigurableOption optional2 = null;
+                        if (!element1.isJsonNull()) {
+                            optional2 = new SelectedConfigurableOption(jsonAsObject(element1, key));
+                        }
+
+                        list1.add(optional2);
+                    }
+
+                    responseData.put(key, list1);
+
+                    break;
+                }
+
+                case "customizable_options": {
+                    List<SelectedCustomizableOption> list1 = new ArrayList<>();
+                    for (JsonElement element1 : jsonAsArray(field.getValue(), key)) {
+                        SelectedCustomizableOption optional2 = null;
+                        if (!element1.isJsonNull()) {
+                            optional2 = new SelectedCustomizableOption(jsonAsObject(element1, key));
+                        }
+
+                        list1.add(optional2);
+                    }
+
+                    responseData.put(key, list1);
+
+                    break;
+                }
+
+                case "id": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+
+                    break;
+                }
+
+                case "product": {
+                    responseData.put(key, UnknownProductInterface.create(jsonAsObject(field.getValue(), key)));
+
+                    break;
+                }
+
+                case "quantity": {
+                    responseData.put(key, jsonAsDouble(field.getValue(), key));
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "ConfigurableCartItem";
+    }
+
+    public List<SelectedConfigurableOption> getConfigurableOptions() {
+        return (List<SelectedConfigurableOption>) get("configurable_options");
+    }
+
+    public ConfigurableCartItem setConfigurableOptions(List<SelectedConfigurableOption> arg) {
+        optimisticData.put(getKey("configurable_options"), arg);
+        return this;
+    }
+
+    public List<SelectedCustomizableOption> getCustomizableOptions() {
+        return (List<SelectedCustomizableOption>) get("customizable_options");
+    }
+
+    public ConfigurableCartItem setCustomizableOptions(List<SelectedCustomizableOption> arg) {
+        optimisticData.put(getKey("customizable_options"), arg);
+        return this;
+    }
+
+    public String getId() {
+        return (String) get("id");
+    }
+
+    public ConfigurableCartItem setId(String arg) {
+        optimisticData.put(getKey("id"), arg);
+        return this;
+    }
+
+    public ProductInterface getProduct() {
+        return (ProductInterface) get("product");
+    }
+
+    public ConfigurableCartItem setProduct(ProductInterface arg) {
+        optimisticData.put(getKey("product"), arg);
+        return this;
+    }
+
+    public Double getQuantity() {
+        return (Double) get("quantity");
+    }
+
+    public ConfigurableCartItem setQuantity(Double arg) {
+        optimisticData.put(getKey("quantity"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "configurable_options": return true;
+
+            case "customizable_options": return true;
+
+            case "id": return false;
+
+            case "product": return false;
+
+            case "quantity": return false;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/ConfigurableCartItemQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/ConfigurableCartItemQuery.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * 
+ */
+public class ConfigurableCartItemQuery extends AbstractQuery<ConfigurableCartItemQuery> {
+    ConfigurableCartItemQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    public ConfigurableCartItemQuery configurableOptions(SelectedConfigurableOptionQueryDefinition queryDef) {
+        startField("configurable_options");
+
+        _queryBuilder.append('{');
+        queryDef.define(new SelectedConfigurableOptionQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public ConfigurableCartItemQuery customizableOptions(SelectedCustomizableOptionQueryDefinition queryDef) {
+        startField("customizable_options");
+
+        _queryBuilder.append('{');
+        queryDef.define(new SelectedCustomizableOptionQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public ConfigurableCartItemQuery id() {
+        startField("id");
+
+        return this;
+    }
+
+    public ConfigurableCartItemQuery product(ProductInterfaceQueryDefinition queryDef) {
+        startField("product");
+
+        _queryBuilder.append('{');
+        queryDef.define(new ProductInterfaceQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public ConfigurableCartItemQuery quantity() {
+        startField("quantity");
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/ConfigurableCartItemQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/ConfigurableCartItemQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface ConfigurableCartItemQueryDefinition {
+    void define(ConfigurableCartItemQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/ConfigurableProductCartItemInput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/ConfigurableProductCartItemInput.java
@@ -1,0 +1,111 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.io.Serializable;
+import java.util.List;
+
+import com.shopify.graphql.support.AbstractQuery;
+import com.shopify.graphql.support.Input;
+
+public class ConfigurableProductCartItemInput implements Serializable {
+    private CartItemInput data;
+
+    private String variantSku;
+
+    private Input<List<CustomizableOptionInput>> customizableOptions = Input.undefined();
+
+    public ConfigurableProductCartItemInput(CartItemInput data, String variantSku) {
+        this.data = data;
+
+        this.variantSku = variantSku;
+    }
+
+    public CartItemInput getData() {
+        return data;
+    }
+
+    public ConfigurableProductCartItemInput setData(CartItemInput data) {
+        this.data = data;
+        return this;
+    }
+
+    public String getVariantSku() {
+        return variantSku;
+    }
+
+    public ConfigurableProductCartItemInput setVariantSku(String variantSku) {
+        this.variantSku = variantSku;
+        return this;
+    }
+
+    public List<CustomizableOptionInput> getCustomizableOptions() {
+        return customizableOptions.getValue();
+    }
+
+    public Input<List<CustomizableOptionInput>> getCustomizableOptionsInput() {
+        return customizableOptions;
+    }
+
+    public ConfigurableProductCartItemInput setCustomizableOptions(List<CustomizableOptionInput> customizableOptions) {
+        this.customizableOptions = Input.optional(customizableOptions);
+        return this;
+    }
+
+    public ConfigurableProductCartItemInput setCustomizableOptionsInput(Input<List<CustomizableOptionInput>> customizableOptions) {
+        if (customizableOptions == null) {
+            throw new IllegalArgumentException("Input can not be null");
+        }
+        this.customizableOptions = customizableOptions;
+        return this;
+    }
+
+    public void appendTo(StringBuilder _queryBuilder) {
+        String separator = "";
+        _queryBuilder.append('{');
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("data:");
+        data.appendTo(_queryBuilder);
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("variant_sku:");
+        AbstractQuery.appendQuotedString(_queryBuilder, variantSku.toString());
+
+        if (this.customizableOptions.isDefined()) {
+            _queryBuilder.append(separator);
+            separator = ",";
+            _queryBuilder.append("customizable_options:");
+            if (customizableOptions.getValue() != null) {
+                _queryBuilder.append('[');
+                {
+                    String listSeperator1 = "";
+                    for (CustomizableOptionInput item1 : customizableOptions.getValue()) {
+                        _queryBuilder.append(listSeperator1);
+                        listSeperator1 = ",";
+                        item1.appendTo(_queryBuilder);
+                    }
+                }
+                _queryBuilder.append(']');
+            } else {
+                _queryBuilder.append("null");
+            }
+        }
+
+        _queryBuilder.append('}');
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/Currency.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/Currency.java
@@ -100,6 +100,28 @@ public class Currency extends AbstractResponse<Currency> {
                     break;
                 }
 
+                case "default_display_currency_code": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "default_display_currency_symbol": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
                 case "exchange_rates": {
                     List<ExchangeRate> optional1 = null;
                     if (!field.getValue().isJsonNull()) {
@@ -181,6 +203,24 @@ public class Currency extends AbstractResponse<Currency> {
         return this;
     }
 
+    public String getDefaultDisplayCurrencyCode() {
+        return (String) get("default_display_currency_code");
+    }
+
+    public Currency setDefaultDisplayCurrencyCode(String arg) {
+        optimisticData.put(getKey("default_display_currency_code"), arg);
+        return this;
+    }
+
+    public String getDefaultDisplayCurrencySymbol() {
+        return (String) get("default_display_currency_symbol");
+    }
+
+    public Currency setDefaultDisplayCurrencySymbol(String arg) {
+        optimisticData.put(getKey("default_display_currency_symbol"), arg);
+        return this;
+    }
+
     public List<ExchangeRate> getExchangeRates() {
         return (List<ExchangeRate>) get("exchange_rates");
     }
@@ -201,6 +241,10 @@ public class Currency extends AbstractResponse<Currency> {
             case "default_display_currecy_code": return false;
 
             case "default_display_currecy_symbol": return false;
+
+            case "default_display_currency_code": return false;
+
+            case "default_display_currency_symbol": return false;
 
             case "exchange_rates": return true;
 

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CurrencyQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CurrencyQuery.java
@@ -54,6 +54,18 @@ public class CurrencyQuery extends AbstractQuery<CurrencyQuery> {
         return this;
     }
 
+    public CurrencyQuery defaultDisplayCurrencyCode() {
+        startField("default_display_currency_code");
+
+        return this;
+    }
+
+    public CurrencyQuery defaultDisplayCurrencySymbol() {
+        startField("default_display_currency_symbol");
+
+        return this;
+    }
+
     public CurrencyQuery exchangeRates(ExchangeRateQueryDefinition queryDef) {
         startField("exchange_rates");
 

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/Customer.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/Customer.java
@@ -122,6 +122,17 @@ public class Customer extends AbstractResponse<Customer> {
                     break;
                 }
 
+                case "gender": {
+                    Integer optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsInteger(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
                 case "group_id": {
                     Integer optional1 = null;
                     if (!field.getValue().isJsonNull()) {
@@ -317,6 +328,19 @@ public class Customer extends AbstractResponse<Customer> {
     }
 
     /**
+     * The customer&#39;s gender(Male - 1, Female - 2)
+     */
+
+    public Integer getGender() {
+        return (Integer) get("gender");
+    }
+
+    public Customer setGender(Integer arg) {
+        optimisticData.put(getKey("gender"), arg);
+        return this;
+    }
+
+    /**
      * The group assigned to the user. Default values are 0 (Not logged in), 1 (General), 2 (Wholesale),
      * and 3 (Retailer)
      */
@@ -436,6 +460,8 @@ public class Customer extends AbstractResponse<Customer> {
             case "email": return false;
 
             case "firstname": return false;
+
+            case "gender": return false;
 
             case "group_id": return false;
 

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomerPaymentTokens.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomerPaymentTokens.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * 
+ */
+public class CustomerPaymentTokens extends AbstractResponse<CustomerPaymentTokens> {
+    public CustomerPaymentTokens() {
+    }
+
+    public CustomerPaymentTokens(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "items": {
+                    List<PaymentToken> list1 = new ArrayList<>();
+                    for (JsonElement element1 : jsonAsArray(field.getValue(), key)) {
+                        PaymentToken optional2 = null;
+                        if (!element1.isJsonNull()) {
+                            optional2 = new PaymentToken(jsonAsObject(element1, key));
+                        }
+
+                        list1.add(optional2);
+                    }
+
+                    responseData.put(key, list1);
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "CustomerPaymentTokens";
+    }
+
+    /**
+     * An array of payment tokens
+     */
+
+    public List<PaymentToken> getItems() {
+        return (List<PaymentToken>) get("items");
+    }
+
+    public CustomerPaymentTokens setItems(List<PaymentToken> arg) {
+        optimisticData.put(getKey("items"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "items": return true;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomerPaymentTokensQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomerPaymentTokensQuery.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * 
+ */
+public class CustomerPaymentTokensQuery extends AbstractQuery<CustomerPaymentTokensQuery> {
+    CustomerPaymentTokensQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    /**
+     * An array of payment tokens
+     */
+    public CustomerPaymentTokensQuery items(PaymentTokenQueryDefinition queryDef) {
+        startField("items");
+
+        _queryBuilder.append('{');
+        queryDef.define(new PaymentTokenQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomerPaymentTokensQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomerPaymentTokensQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface CustomerPaymentTokensQueryDefinition {
+    void define(CustomerPaymentTokensQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomerQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomerQuery.java
@@ -92,6 +92,15 @@ public class CustomerQuery extends AbstractQuery<CustomerQuery> {
     }
 
     /**
+     * The customer&#39;s gender(Male - 1, Female - 2)
+     */
+    public CustomerQuery gender() {
+        startField("gender");
+
+        return this;
+    }
+
+    /**
      * The group assigned to the user. Default values are 0 (Not logged in), 1 (General), 2 (Wholesale),
      * and 3 (Retailer)
      */

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableCheckboxOption.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableCheckboxOption.java
@@ -1,0 +1,200 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * CustomizableCheckbbixOption contains information about a set of checkbox values that are defined as
+ * part of a customizable option
+ */
+public class CustomizableCheckboxOption extends AbstractResponse<CustomizableCheckboxOption> implements CustomizableOptionInterface {
+    public CustomizableCheckboxOption() {
+    }
+
+    public CustomizableCheckboxOption(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "option_id": {
+                    Integer optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsInteger(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "required": {
+                    Boolean optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsBoolean(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "sort_order": {
+                    Integer optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsInteger(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "title": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "value": {
+                    List<CustomizableCheckboxValue> optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        List<CustomizableCheckboxValue> list1 = new ArrayList<>();
+                        for (JsonElement element1 : jsonAsArray(field.getValue(), key)) {
+                            CustomizableCheckboxValue optional2 = null;
+                            if (!element1.isJsonNull()) {
+                                optional2 = new CustomizableCheckboxValue(jsonAsObject(element1, key));
+                            }
+
+                            list1.add(optional2);
+                        }
+
+                        optional1 = list1;
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "CustomizableCheckboxOption";
+    }
+
+    /**
+     * Option ID
+     */
+
+    public Integer getOptionId() {
+        return (Integer) get("option_id");
+    }
+
+    public CustomizableCheckboxOption setOptionId(Integer arg) {
+        optimisticData.put(getKey("option_id"), arg);
+        return this;
+    }
+
+    /**
+     * Indicates whether the option is required
+     */
+
+    public Boolean getRequired() {
+        return (Boolean) get("required");
+    }
+
+    public CustomizableCheckboxOption setRequired(Boolean arg) {
+        optimisticData.put(getKey("required"), arg);
+        return this;
+    }
+
+    /**
+     * The order in which the option is displayed
+     */
+
+    public Integer getSortOrder() {
+        return (Integer) get("sort_order");
+    }
+
+    public CustomizableCheckboxOption setSortOrder(Integer arg) {
+        optimisticData.put(getKey("sort_order"), arg);
+        return this;
+    }
+
+    /**
+     * The display name for this option
+     */
+
+    public String getTitle() {
+        return (String) get("title");
+    }
+
+    public CustomizableCheckboxOption setTitle(String arg) {
+        optimisticData.put(getKey("title"), arg);
+        return this;
+    }
+
+    /**
+     * An array that defines a set of checkbox values
+     */
+
+    public List<CustomizableCheckboxValue> getValue() {
+        return (List<CustomizableCheckboxValue>) get("value");
+    }
+
+    public CustomizableCheckboxOption setValue(List<CustomizableCheckboxValue> arg) {
+        optimisticData.put(getKey("value"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "option_id": return false;
+
+            case "required": return false;
+
+            case "sort_order": return false;
+
+            case "title": return false;
+
+            case "value": return true;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableCheckboxOptionQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableCheckboxOptionQuery.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * CustomizableCheckbbixOption contains information about a set of checkbox values that are defined as
+ * part of a customizable option
+ */
+public class CustomizableCheckboxOptionQuery extends AbstractQuery<CustomizableCheckboxOptionQuery> {
+    CustomizableCheckboxOptionQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    /**
+     * Option ID
+     */
+    public CustomizableCheckboxOptionQuery optionId() {
+        startField("option_id");
+
+        return this;
+    }
+
+    /**
+     * Indicates whether the option is required
+     */
+    public CustomizableCheckboxOptionQuery required() {
+        startField("required");
+
+        return this;
+    }
+
+    /**
+     * The order in which the option is displayed
+     */
+    public CustomizableCheckboxOptionQuery sortOrder() {
+        startField("sort_order");
+
+        return this;
+    }
+
+    /**
+     * The display name for this option
+     */
+    public CustomizableCheckboxOptionQuery title() {
+        startField("title");
+
+        return this;
+    }
+
+    /**
+     * An array that defines a set of checkbox values
+     */
+    public CustomizableCheckboxOptionQuery value(CustomizableCheckboxValueQueryDefinition queryDef) {
+        startField("value");
+
+        _queryBuilder.append('{');
+        queryDef.define(new CustomizableCheckboxValueQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableCheckboxOptionQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableCheckboxOptionQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface CustomizableCheckboxOptionQueryDefinition {
+    void define(CustomizableCheckboxOptionQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableCheckboxValue.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableCheckboxValue.java
@@ -1,0 +1,214 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * CustomizableCheckboxValue defines the price and sku of a product whose page contains a customized
+ * set of checkbox values
+ */
+public class CustomizableCheckboxValue extends AbstractResponse<CustomizableCheckboxValue> {
+    public CustomizableCheckboxValue() {
+    }
+
+    public CustomizableCheckboxValue(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "option_type_id": {
+                    Integer optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsInteger(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "price": {
+                    Double optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsDouble(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "price_type": {
+                    PriceTypeEnum optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = PriceTypeEnum.fromGraphQl(jsonAsString(field.getValue(), key));
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "sku": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "sort_order": {
+                    Integer optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsInteger(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "title": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "CustomizableCheckboxValue";
+    }
+
+    /**
+     * The ID assigned to the value
+     */
+
+    public Integer getOptionTypeId() {
+        return (Integer) get("option_type_id");
+    }
+
+    public CustomizableCheckboxValue setOptionTypeId(Integer arg) {
+        optimisticData.put(getKey("option_type_id"), arg);
+        return this;
+    }
+
+    /**
+     * The price assigned to this option
+     */
+
+    public Double getPrice() {
+        return (Double) get("price");
+    }
+
+    public CustomizableCheckboxValue setPrice(Double arg) {
+        optimisticData.put(getKey("price"), arg);
+        return this;
+    }
+
+    /**
+     * FIXED, PERCENT, or DYNAMIC
+     */
+
+    public PriceTypeEnum getPriceType() {
+        return (PriceTypeEnum) get("price_type");
+    }
+
+    public CustomizableCheckboxValue setPriceType(PriceTypeEnum arg) {
+        optimisticData.put(getKey("price_type"), arg);
+        return this;
+    }
+
+    /**
+     * The Stock Keeping Unit for this option
+     */
+
+    public String getSku() {
+        return (String) get("sku");
+    }
+
+    public CustomizableCheckboxValue setSku(String arg) {
+        optimisticData.put(getKey("sku"), arg);
+        return this;
+    }
+
+    /**
+     * The order in which the checkbox value is displayed
+     */
+
+    public Integer getSortOrder() {
+        return (Integer) get("sort_order");
+    }
+
+    public CustomizableCheckboxValue setSortOrder(Integer arg) {
+        optimisticData.put(getKey("sort_order"), arg);
+        return this;
+    }
+
+    /**
+     * The display name for this option
+     */
+
+    public String getTitle() {
+        return (String) get("title");
+    }
+
+    public CustomizableCheckboxValue setTitle(String arg) {
+        optimisticData.put(getKey("title"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "option_type_id": return false;
+
+            case "price": return false;
+
+            case "price_type": return false;
+
+            case "sku": return false;
+
+            case "sort_order": return false;
+
+            case "title": return false;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableCheckboxValueQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableCheckboxValueQuery.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * CustomizableCheckboxValue defines the price and sku of a product whose page contains a customized
+ * set of checkbox values
+ */
+public class CustomizableCheckboxValueQuery extends AbstractQuery<CustomizableCheckboxValueQuery> {
+    CustomizableCheckboxValueQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    /**
+     * The ID assigned to the value
+     */
+    public CustomizableCheckboxValueQuery optionTypeId() {
+        startField("option_type_id");
+
+        return this;
+    }
+
+    /**
+     * The price assigned to this option
+     */
+    public CustomizableCheckboxValueQuery price() {
+        startField("price");
+
+        return this;
+    }
+
+    /**
+     * FIXED, PERCENT, or DYNAMIC
+     */
+    public CustomizableCheckboxValueQuery priceType() {
+        startField("price_type");
+
+        return this;
+    }
+
+    /**
+     * The Stock Keeping Unit for this option
+     */
+    public CustomizableCheckboxValueQuery sku() {
+        startField("sku");
+
+        return this;
+    }
+
+    /**
+     * The order in which the checkbox value is displayed
+     */
+    public CustomizableCheckboxValueQuery sortOrder() {
+        startField("sort_order");
+
+        return this;
+    }
+
+    /**
+     * The display name for this option
+     */
+    public CustomizableCheckboxValueQuery title() {
+        startField("title");
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableCheckboxValueQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableCheckboxValueQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface CustomizableCheckboxValueQueryDefinition {
+    void define(CustomizableCheckboxValueQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableMultipleOption.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableMultipleOption.java
@@ -1,0 +1,200 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * CustomizableMultipleOption contains information about a multiselect that is defined as part of a
+ * customizable option
+ */
+public class CustomizableMultipleOption extends AbstractResponse<CustomizableMultipleOption> implements CustomizableOptionInterface {
+    public CustomizableMultipleOption() {
+    }
+
+    public CustomizableMultipleOption(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "option_id": {
+                    Integer optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsInteger(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "required": {
+                    Boolean optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsBoolean(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "sort_order": {
+                    Integer optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsInteger(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "title": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "value": {
+                    List<CustomizableMultipleValue> optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        List<CustomizableMultipleValue> list1 = new ArrayList<>();
+                        for (JsonElement element1 : jsonAsArray(field.getValue(), key)) {
+                            CustomizableMultipleValue optional2 = null;
+                            if (!element1.isJsonNull()) {
+                                optional2 = new CustomizableMultipleValue(jsonAsObject(element1, key));
+                            }
+
+                            list1.add(optional2);
+                        }
+
+                        optional1 = list1;
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "CustomizableMultipleOption";
+    }
+
+    /**
+     * Option ID
+     */
+
+    public Integer getOptionId() {
+        return (Integer) get("option_id");
+    }
+
+    public CustomizableMultipleOption setOptionId(Integer arg) {
+        optimisticData.put(getKey("option_id"), arg);
+        return this;
+    }
+
+    /**
+     * Indicates whether the option is required
+     */
+
+    public Boolean getRequired() {
+        return (Boolean) get("required");
+    }
+
+    public CustomizableMultipleOption setRequired(Boolean arg) {
+        optimisticData.put(getKey("required"), arg);
+        return this;
+    }
+
+    /**
+     * The order in which the option is displayed
+     */
+
+    public Integer getSortOrder() {
+        return (Integer) get("sort_order");
+    }
+
+    public CustomizableMultipleOption setSortOrder(Integer arg) {
+        optimisticData.put(getKey("sort_order"), arg);
+        return this;
+    }
+
+    /**
+     * The display name for this option
+     */
+
+    public String getTitle() {
+        return (String) get("title");
+    }
+
+    public CustomizableMultipleOption setTitle(String arg) {
+        optimisticData.put(getKey("title"), arg);
+        return this;
+    }
+
+    /**
+     * An array that defines the set of options for a multiselect
+     */
+
+    public List<CustomizableMultipleValue> getValue() {
+        return (List<CustomizableMultipleValue>) get("value");
+    }
+
+    public CustomizableMultipleOption setValue(List<CustomizableMultipleValue> arg) {
+        optimisticData.put(getKey("value"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "option_id": return false;
+
+            case "required": return false;
+
+            case "sort_order": return false;
+
+            case "title": return false;
+
+            case "value": return true;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableMultipleOptionQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableMultipleOptionQuery.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * CustomizableMultipleOption contains information about a multiselect that is defined as part of a
+ * customizable option
+ */
+public class CustomizableMultipleOptionQuery extends AbstractQuery<CustomizableMultipleOptionQuery> {
+    CustomizableMultipleOptionQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    /**
+     * Option ID
+     */
+    public CustomizableMultipleOptionQuery optionId() {
+        startField("option_id");
+
+        return this;
+    }
+
+    /**
+     * Indicates whether the option is required
+     */
+    public CustomizableMultipleOptionQuery required() {
+        startField("required");
+
+        return this;
+    }
+
+    /**
+     * The order in which the option is displayed
+     */
+    public CustomizableMultipleOptionQuery sortOrder() {
+        startField("sort_order");
+
+        return this;
+    }
+
+    /**
+     * The display name for this option
+     */
+    public CustomizableMultipleOptionQuery title() {
+        startField("title");
+
+        return this;
+    }
+
+    /**
+     * An array that defines the set of options for a multiselect
+     */
+    public CustomizableMultipleOptionQuery value(CustomizableMultipleValueQueryDefinition queryDef) {
+        startField("value");
+
+        _queryBuilder.append('{');
+        queryDef.define(new CustomizableMultipleValueQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableMultipleOptionQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableMultipleOptionQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface CustomizableMultipleOptionQueryDefinition {
+    void define(CustomizableMultipleOptionQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableMultipleValue.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableMultipleValue.java
@@ -1,0 +1,214 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * CustomizableMultipleValue defines the price and sku of a product whose page contains a customized
+ * multiselect
+ */
+public class CustomizableMultipleValue extends AbstractResponse<CustomizableMultipleValue> {
+    public CustomizableMultipleValue() {
+    }
+
+    public CustomizableMultipleValue(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "option_type_id": {
+                    Integer optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsInteger(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "price": {
+                    Double optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsDouble(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "price_type": {
+                    PriceTypeEnum optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = PriceTypeEnum.fromGraphQl(jsonAsString(field.getValue(), key));
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "sku": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "sort_order": {
+                    Integer optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsInteger(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "title": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "CustomizableMultipleValue";
+    }
+
+    /**
+     * The ID assigned to the value
+     */
+
+    public Integer getOptionTypeId() {
+        return (Integer) get("option_type_id");
+    }
+
+    public CustomizableMultipleValue setOptionTypeId(Integer arg) {
+        optimisticData.put(getKey("option_type_id"), arg);
+        return this;
+    }
+
+    /**
+     * The price assigned to this option
+     */
+
+    public Double getPrice() {
+        return (Double) get("price");
+    }
+
+    public CustomizableMultipleValue setPrice(Double arg) {
+        optimisticData.put(getKey("price"), arg);
+        return this;
+    }
+
+    /**
+     * FIXED, PERCENT, or DYNAMIC
+     */
+
+    public PriceTypeEnum getPriceType() {
+        return (PriceTypeEnum) get("price_type");
+    }
+
+    public CustomizableMultipleValue setPriceType(PriceTypeEnum arg) {
+        optimisticData.put(getKey("price_type"), arg);
+        return this;
+    }
+
+    /**
+     * The Stock Keeping Unit for this option
+     */
+
+    public String getSku() {
+        return (String) get("sku");
+    }
+
+    public CustomizableMultipleValue setSku(String arg) {
+        optimisticData.put(getKey("sku"), arg);
+        return this;
+    }
+
+    /**
+     * The order in which the option is displayed
+     */
+
+    public Integer getSortOrder() {
+        return (Integer) get("sort_order");
+    }
+
+    public CustomizableMultipleValue setSortOrder(Integer arg) {
+        optimisticData.put(getKey("sort_order"), arg);
+        return this;
+    }
+
+    /**
+     * The display name for this option
+     */
+
+    public String getTitle() {
+        return (String) get("title");
+    }
+
+    public CustomizableMultipleValue setTitle(String arg) {
+        optimisticData.put(getKey("title"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "option_type_id": return false;
+
+            case "price": return false;
+
+            case "price_type": return false;
+
+            case "sku": return false;
+
+            case "sort_order": return false;
+
+            case "title": return false;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableMultipleValueQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableMultipleValueQuery.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * CustomizableMultipleValue defines the price and sku of a product whose page contains a customized
+ * multiselect
+ */
+public class CustomizableMultipleValueQuery extends AbstractQuery<CustomizableMultipleValueQuery> {
+    CustomizableMultipleValueQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    /**
+     * The ID assigned to the value
+     */
+    public CustomizableMultipleValueQuery optionTypeId() {
+        startField("option_type_id");
+
+        return this;
+    }
+
+    /**
+     * The price assigned to this option
+     */
+    public CustomizableMultipleValueQuery price() {
+        startField("price");
+
+        return this;
+    }
+
+    /**
+     * FIXED, PERCENT, or DYNAMIC
+     */
+    public CustomizableMultipleValueQuery priceType() {
+        startField("price_type");
+
+        return this;
+    }
+
+    /**
+     * The Stock Keeping Unit for this option
+     */
+    public CustomizableMultipleValueQuery sku() {
+        startField("sku");
+
+        return this;
+    }
+
+    /**
+     * The order in which the option is displayed
+     */
+    public CustomizableMultipleValueQuery sortOrder() {
+        startField("sort_order");
+
+        return this;
+    }
+
+    /**
+     * The display name for this option
+     */
+    public CustomizableMultipleValueQuery title() {
+        startField("title");
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableMultipleValueQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableMultipleValueQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface CustomizableMultipleValueQueryDefinition {
+    void define(CustomizableMultipleValueQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableOptionInput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableOptionInput.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.io.Serializable;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+public class CustomizableOptionInput implements Serializable {
+    private int id;
+
+    private String valueString;
+
+    public CustomizableOptionInput(int id, String valueString) {
+        this.id = id;
+
+        this.valueString = valueString;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public CustomizableOptionInput setId(int id) {
+        this.id = id;
+        return this;
+    }
+
+    public String getValueString() {
+        return valueString;
+    }
+
+    public CustomizableOptionInput setValueString(String valueString) {
+        this.valueString = valueString;
+        return this;
+    }
+
+    public void appendTo(StringBuilder _queryBuilder) {
+        String separator = "";
+        _queryBuilder.append('{');
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("id:");
+        _queryBuilder.append(id);
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("value_string:");
+        AbstractQuery.appendQuotedString(_queryBuilder, valueString.toString());
+
+        _queryBuilder.append('}');
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableOptionInterfaceQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableOptionInterfaceQuery.java
@@ -70,6 +70,13 @@ public class CustomizableOptionInterfaceQuery extends AbstractQuery<Customizable
         return this;
     }
 
+    public CustomizableOptionInterfaceQuery onCustomizableCheckboxOption(CustomizableCheckboxOptionQueryDefinition queryDef) {
+        startInlineFragment("CustomizableCheckboxOption");
+        queryDef.define(new CustomizableCheckboxOptionQuery(_queryBuilder));
+        _queryBuilder.append('}');
+        return this;
+    }
+
     public CustomizableOptionInterfaceQuery onCustomizableDateOption(CustomizableDateOptionQueryDefinition queryDef) {
         startInlineFragment("CustomizableDateOption");
         queryDef.define(new CustomizableDateOptionQuery(_queryBuilder));
@@ -94,6 +101,13 @@ public class CustomizableOptionInterfaceQuery extends AbstractQuery<Customizable
     public CustomizableOptionInterfaceQuery onCustomizableFileOption(CustomizableFileOptionQueryDefinition queryDef) {
         startInlineFragment("CustomizableFileOption");
         queryDef.define(new CustomizableFileOptionQuery(_queryBuilder));
+        _queryBuilder.append('}');
+        return this;
+    }
+
+    public CustomizableOptionInterfaceQuery onCustomizableMultipleOption(CustomizableMultipleOptionQueryDefinition queryDef) {
+        startInlineFragment("CustomizableMultipleOption");
+        queryDef.define(new CustomizableMultipleOptionQuery(_queryBuilder));
         _queryBuilder.append('}');
         return this;
     }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/DeletePaymentTokenOutput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/DeletePaymentTokenOutput.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * 
+ */
+public class DeletePaymentTokenOutput extends AbstractResponse<DeletePaymentTokenOutput> {
+    public DeletePaymentTokenOutput() {
+    }
+
+    public DeletePaymentTokenOutput(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "customerPaymentTokens": {
+                    CustomerPaymentTokens optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = new CustomerPaymentTokens(jsonAsObject(field.getValue(), key));
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "result": {
+                    responseData.put(key, jsonAsBoolean(field.getValue(), key));
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "DeletePaymentTokenOutput";
+    }
+
+    public CustomerPaymentTokens getCustomerPaymentTokens() {
+        return (CustomerPaymentTokens) get("customerPaymentTokens");
+    }
+
+    public DeletePaymentTokenOutput setCustomerPaymentTokens(CustomerPaymentTokens arg) {
+        optimisticData.put(getKey("customerPaymentTokens"), arg);
+        return this;
+    }
+
+    public Boolean getResult() {
+        return (Boolean) get("result");
+    }
+
+    public DeletePaymentTokenOutput setResult(Boolean arg) {
+        optimisticData.put(getKey("result"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "customerPaymentTokens": return true;
+
+            case "result": return false;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/DeletePaymentTokenOutputQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/DeletePaymentTokenOutputQuery.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * 
+ */
+public class DeletePaymentTokenOutputQuery extends AbstractQuery<DeletePaymentTokenOutputQuery> {
+    DeletePaymentTokenOutputQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    public DeletePaymentTokenOutputQuery customerPaymentTokens(CustomerPaymentTokensQueryDefinition queryDef) {
+        startField("customerPaymentTokens");
+
+        _queryBuilder.append('{');
+        queryDef.define(new CustomerPaymentTokensQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public DeletePaymentTokenOutputQuery result() {
+        startField("result");
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/DeletePaymentTokenOutputQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/DeletePaymentTokenOutputQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface DeletePaymentTokenOutputQueryDefinition {
+    void define(DeletePaymentTokenOutputQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/EntityUrl.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/EntityUrl.java
@@ -22,7 +22,7 @@ import com.shopify.graphql.support.AbstractResponse;
 import com.shopify.graphql.support.SchemaViolationError;
 
 /**
- * EntityUrl is an output object containing the `id`, `canonical_url`, and `type` attributes
+ * EntityUrl is an output object containing the `id`, `relative_url`, and `type` attributes
  */
 public class EntityUrl extends AbstractResponse<EntityUrl> {
     public EntityUrl() {
@@ -48,6 +48,17 @@ public class EntityUrl extends AbstractResponse<EntityUrl> {
                     Integer optional1 = null;
                     if (!field.getValue().isJsonNull()) {
                         optional1 = jsonAsInteger(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "relative_url": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
                     }
 
                     responseData.put(key, optional1);
@@ -81,11 +92,6 @@ public class EntityUrl extends AbstractResponse<EntityUrl> {
         return "EntityUrl";
     }
 
-    /**
-     * The internal relative URL. If the specified  url is a redirect, the query returns the redirected
-     * URL, not the original.
-     */
-
     public String getCanonicalUrl() {
         return (String) get("canonical_url");
     }
@@ -110,6 +116,20 @@ public class EntityUrl extends AbstractResponse<EntityUrl> {
     }
 
     /**
+     * The internal relative URL. If the specified  url is a redirect, the query returns the redirected
+     * URL, not the original.
+     */
+
+    public String getRelativeUrl() {
+        return (String) get("relative_url");
+    }
+
+    public EntityUrl setRelativeUrl(String arg) {
+        optimisticData.put(getKey("relative_url"), arg);
+        return this;
+    }
+
+    /**
      * One of PRODUCT, CATEGORY, or CMS_PAGE.
      */
 
@@ -127,6 +147,8 @@ public class EntityUrl extends AbstractResponse<EntityUrl> {
             case "canonical_url": return false;
 
             case "id": return false;
+
+            case "relative_url": return false;
 
             case "type": return false;
 

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/EntityUrlQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/EntityUrlQuery.java
@@ -17,17 +17,13 @@ package com.adobe.cq.commerce.magento.graphql;
 import com.shopify.graphql.support.AbstractQuery;
 
 /**
- * EntityUrl is an output object containing the `id`, `canonical_url`, and `type` attributes
+ * EntityUrl is an output object containing the `id`, `relative_url`, and `type` attributes
  */
 public class EntityUrlQuery extends AbstractQuery<EntityUrlQuery> {
     EntityUrlQuery(StringBuilder _queryBuilder) {
         super(_queryBuilder);
     }
 
-    /**
-     * The internal relative URL. If the specified  url is a redirect, the query returns the redirected
-     * URL, not the original.
-     */
     public EntityUrlQuery canonicalUrl() {
         startField("canonical_url");
 
@@ -40,6 +36,16 @@ public class EntityUrlQuery extends AbstractQuery<EntityUrlQuery> {
      */
     public EntityUrlQuery id() {
         startField("id");
+
+        return this;
+    }
+
+    /**
+     * The internal relative URL. If the specified  url is a redirect, the query returns the redirected
+     * URL, not the original.
+     */
+    public EntityUrlQuery relativeUrl() {
+        startField("relative_url");
 
         return this;
     }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/IsEmailAvailableOutput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/IsEmailAvailableOutput.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * 
+ */
+public class IsEmailAvailableOutput extends AbstractResponse<IsEmailAvailableOutput> {
+    public IsEmailAvailableOutput() {
+    }
+
+    public IsEmailAvailableOutput(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "is_email_available": {
+                    Boolean optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsBoolean(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "IsEmailAvailableOutput";
+    }
+
+    /**
+     * Is email availabel value
+     */
+
+    public Boolean getIsEmailAvailable() {
+        return (Boolean) get("is_email_available");
+    }
+
+    public IsEmailAvailableOutput setIsEmailAvailable(Boolean arg) {
+        optimisticData.put(getKey("is_email_available"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "is_email_available": return false;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/IsEmailAvailableOutputQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/IsEmailAvailableOutputQuery.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * 
+ */
+public class IsEmailAvailableOutputQuery extends AbstractQuery<IsEmailAvailableOutputQuery> {
+    IsEmailAvailableOutputQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    /**
+     * Is email availabel value
+     */
+    public IsEmailAvailableOutputQuery isEmailAvailable() {
+        startField("is_email_available");
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/IsEmailAvailableOutputQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/IsEmailAvailableOutputQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface IsEmailAvailableOutputQueryDefinition {
+    void define(IsEmailAvailableOutputQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/Mutation.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/Mutation.java
@@ -33,6 +33,50 @@ public class Mutation extends AbstractResponse<Mutation> {
             String key = field.getKey();
             String fieldName = getFieldName(key);
             switch (fieldName) {
+                case "addConfigurableProductsToCart": {
+                    AddConfigurableProductsToCartOutput optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = new AddConfigurableProductsToCartOutput(jsonAsObject(field.getValue(), key));
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "addSimpleProductsToCart": {
+                    AddSimpleProductsToCartOutput optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = new AddSimpleProductsToCartOutput(jsonAsObject(field.getValue(), key));
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "addVirtualProductsToCart": {
+                    AddVirtualProductsToCartOutput optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = new AddVirtualProductsToCartOutput(jsonAsObject(field.getValue(), key));
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "applyCouponToCart": {
+                    ApplyCouponToCartOutput optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = new ApplyCouponToCartOutput(jsonAsObject(field.getValue(), key));
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
                 case "changeCustomerPassword": {
                     Customer optional1 = null;
                     if (!field.getValue().isJsonNull()) {
@@ -88,10 +132,54 @@ public class Mutation extends AbstractResponse<Mutation> {
                     break;
                 }
 
+                case "deletePaymentToken": {
+                    DeletePaymentTokenOutput optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = new DeletePaymentTokenOutput(jsonAsObject(field.getValue(), key));
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
                 case "generateCustomerToken": {
                     CustomerToken optional1 = null;
                     if (!field.getValue().isJsonNull()) {
                         optional1 = new CustomerToken(jsonAsObject(field.getValue(), key));
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "placeOrder": {
+                    PlaceOrderOutput optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = new PlaceOrderOutput(jsonAsObject(field.getValue(), key));
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "removeCouponFromCart": {
+                    RemoveCouponFromCartOutput optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = new RemoveCouponFromCartOutput(jsonAsObject(field.getValue(), key));
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "removeItemFromCart": {
+                    RemoveItemFromCartOutput optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = new RemoveItemFromCartOutput(jsonAsObject(field.getValue(), key));
                     }
 
                     responseData.put(key, optional1);
@@ -114,6 +202,72 @@ public class Mutation extends AbstractResponse<Mutation> {
                     SendEmailToFriendOutput optional1 = null;
                     if (!field.getValue().isJsonNull()) {
                         optional1 = new SendEmailToFriendOutput(jsonAsObject(field.getValue(), key));
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "setBillingAddressOnCart": {
+                    SetBillingAddressOnCartOutput optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = new SetBillingAddressOnCartOutput(jsonAsObject(field.getValue(), key));
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "setGuestEmailOnCart": {
+                    SetGuestEmailOnCartOutput optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = new SetGuestEmailOnCartOutput(jsonAsObject(field.getValue(), key));
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "setPaymentMethodOnCart": {
+                    SetPaymentMethodOnCartOutput optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = new SetPaymentMethodOnCartOutput(jsonAsObject(field.getValue(), key));
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "setShippingAddressesOnCart": {
+                    SetShippingAddressesOnCartOutput optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = new SetShippingAddressesOnCartOutput(jsonAsObject(field.getValue(), key));
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "setShippingMethodsOnCart": {
+                    SetShippingMethodsOnCartOutput optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = new SetShippingMethodsOnCartOutput(jsonAsObject(field.getValue(), key));
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "updateCartItems": {
+                    UpdateCartItemsOutput optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = new UpdateCartItemsOutput(jsonAsObject(field.getValue(), key));
                     }
 
                     responseData.put(key, optional1);
@@ -158,6 +312,42 @@ public class Mutation extends AbstractResponse<Mutation> {
         return "Mutation";
     }
 
+    public AddConfigurableProductsToCartOutput getAddConfigurableProductsToCart() {
+        return (AddConfigurableProductsToCartOutput) get("addConfigurableProductsToCart");
+    }
+
+    public Mutation setAddConfigurableProductsToCart(AddConfigurableProductsToCartOutput arg) {
+        optimisticData.put(getKey("addConfigurableProductsToCart"), arg);
+        return this;
+    }
+
+    public AddSimpleProductsToCartOutput getAddSimpleProductsToCart() {
+        return (AddSimpleProductsToCartOutput) get("addSimpleProductsToCart");
+    }
+
+    public Mutation setAddSimpleProductsToCart(AddSimpleProductsToCartOutput arg) {
+        optimisticData.put(getKey("addSimpleProductsToCart"), arg);
+        return this;
+    }
+
+    public AddVirtualProductsToCartOutput getAddVirtualProductsToCart() {
+        return (AddVirtualProductsToCartOutput) get("addVirtualProductsToCart");
+    }
+
+    public Mutation setAddVirtualProductsToCart(AddVirtualProductsToCartOutput arg) {
+        optimisticData.put(getKey("addVirtualProductsToCart"), arg);
+        return this;
+    }
+
+    public ApplyCouponToCartOutput getApplyCouponToCart() {
+        return (ApplyCouponToCartOutput) get("applyCouponToCart");
+    }
+
+    public Mutation setApplyCouponToCart(ApplyCouponToCartOutput arg) {
+        optimisticData.put(getKey("applyCouponToCart"), arg);
+        return this;
+    }
+
     /**
      * Changes the password for the logged-in customer
      */
@@ -198,7 +388,7 @@ public class Mutation extends AbstractResponse<Mutation> {
     }
 
     /**
-     * Creates empty shopping cart for guest or logged in user
+     * Creates an empty shopping cart for a guest or logged in user
      */
 
     public String getCreateEmptyCart() {
@@ -224,6 +414,19 @@ public class Mutation extends AbstractResponse<Mutation> {
     }
 
     /**
+     * Delete a customer payment token
+     */
+
+    public DeletePaymentTokenOutput getDeletePaymentToken() {
+        return (DeletePaymentTokenOutput) get("deletePaymentToken");
+    }
+
+    public Mutation setDeletePaymentToken(DeletePaymentTokenOutput arg) {
+        optimisticData.put(getKey("deletePaymentToken"), arg);
+        return this;
+    }
+
+    /**
      * Retrieve the customer token
      */
 
@@ -233,6 +436,33 @@ public class Mutation extends AbstractResponse<Mutation> {
 
     public Mutation setGenerateCustomerToken(CustomerToken arg) {
         optimisticData.put(getKey("generateCustomerToken"), arg);
+        return this;
+    }
+
+    public PlaceOrderOutput getPlaceOrder() {
+        return (PlaceOrderOutput) get("placeOrder");
+    }
+
+    public Mutation setPlaceOrder(PlaceOrderOutput arg) {
+        optimisticData.put(getKey("placeOrder"), arg);
+        return this;
+    }
+
+    public RemoveCouponFromCartOutput getRemoveCouponFromCart() {
+        return (RemoveCouponFromCartOutput) get("removeCouponFromCart");
+    }
+
+    public Mutation setRemoveCouponFromCart(RemoveCouponFromCartOutput arg) {
+        optimisticData.put(getKey("removeCouponFromCart"), arg);
+        return this;
+    }
+
+    public RemoveItemFromCartOutput getRemoveItemFromCart() {
+        return (RemoveItemFromCartOutput) get("removeItemFromCart");
+    }
+
+    public Mutation setRemoveItemFromCart(RemoveItemFromCartOutput arg) {
+        optimisticData.put(getKey("removeItemFromCart"), arg);
         return this;
     }
 
@@ -259,6 +489,60 @@ public class Mutation extends AbstractResponse<Mutation> {
 
     public Mutation setSendEmailToFriend(SendEmailToFriendOutput arg) {
         optimisticData.put(getKey("sendEmailToFriend"), arg);
+        return this;
+    }
+
+    public SetBillingAddressOnCartOutput getSetBillingAddressOnCart() {
+        return (SetBillingAddressOnCartOutput) get("setBillingAddressOnCart");
+    }
+
+    public Mutation setSetBillingAddressOnCart(SetBillingAddressOnCartOutput arg) {
+        optimisticData.put(getKey("setBillingAddressOnCart"), arg);
+        return this;
+    }
+
+    public SetGuestEmailOnCartOutput getSetGuestEmailOnCart() {
+        return (SetGuestEmailOnCartOutput) get("setGuestEmailOnCart");
+    }
+
+    public Mutation setSetGuestEmailOnCart(SetGuestEmailOnCartOutput arg) {
+        optimisticData.put(getKey("setGuestEmailOnCart"), arg);
+        return this;
+    }
+
+    public SetPaymentMethodOnCartOutput getSetPaymentMethodOnCart() {
+        return (SetPaymentMethodOnCartOutput) get("setPaymentMethodOnCart");
+    }
+
+    public Mutation setSetPaymentMethodOnCart(SetPaymentMethodOnCartOutput arg) {
+        optimisticData.put(getKey("setPaymentMethodOnCart"), arg);
+        return this;
+    }
+
+    public SetShippingAddressesOnCartOutput getSetShippingAddressesOnCart() {
+        return (SetShippingAddressesOnCartOutput) get("setShippingAddressesOnCart");
+    }
+
+    public Mutation setSetShippingAddressesOnCart(SetShippingAddressesOnCartOutput arg) {
+        optimisticData.put(getKey("setShippingAddressesOnCart"), arg);
+        return this;
+    }
+
+    public SetShippingMethodsOnCartOutput getSetShippingMethodsOnCart() {
+        return (SetShippingMethodsOnCartOutput) get("setShippingMethodsOnCart");
+    }
+
+    public Mutation setSetShippingMethodsOnCart(SetShippingMethodsOnCartOutput arg) {
+        optimisticData.put(getKey("setShippingMethodsOnCart"), arg);
+        return this;
+    }
+
+    public UpdateCartItemsOutput getUpdateCartItems() {
+        return (UpdateCartItemsOutput) get("updateCartItems");
+    }
+
+    public Mutation setUpdateCartItems(UpdateCartItemsOutput arg) {
+        optimisticData.put(getKey("updateCartItems"), arg);
         return this;
     }
 
@@ -290,6 +574,14 @@ public class Mutation extends AbstractResponse<Mutation> {
 
     public boolean unwrapsToObject(String key) {
         switch (getFieldName(key)) {
+            case "addConfigurableProductsToCart": return true;
+
+            case "addSimpleProductsToCart": return true;
+
+            case "addVirtualProductsToCart": return true;
+
+            case "applyCouponToCart": return true;
+
             case "changeCustomerPassword": return true;
 
             case "createCustomer": return true;
@@ -300,11 +592,31 @@ public class Mutation extends AbstractResponse<Mutation> {
 
             case "deleteCustomerAddress": return false;
 
+            case "deletePaymentToken": return true;
+
             case "generateCustomerToken": return true;
+
+            case "placeOrder": return true;
+
+            case "removeCouponFromCart": return true;
+
+            case "removeItemFromCart": return true;
 
             case "revokeCustomerToken": return true;
 
             case "sendEmailToFriend": return true;
+
+            case "setBillingAddressOnCart": return true;
+
+            case "setGuestEmailOnCart": return true;
+
+            case "setPaymentMethodOnCart": return true;
+
+            case "setShippingAddressesOnCart": return true;
+
+            case "setShippingMethodsOnCart": return true;
+
+            case "updateCartItems": return true;
 
             case "updateCustomer": return true;
 

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/MutationQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/MutationQuery.java
@@ -25,6 +25,162 @@ public class MutationQuery extends AbstractQuery<MutationQuery> {
         super(_queryBuilder);
     }
 
+    public class AddConfigurableProductsToCartArguments extends Arguments {
+        AddConfigurableProductsToCartArguments(StringBuilder _queryBuilder) {
+            super(_queryBuilder, true);
+        }
+
+        /**
+         * 
+         */
+        public AddConfigurableProductsToCartArguments input(AddConfigurableProductsToCartInput value) {
+            if (value != null) {
+                startArgument("input");
+                value.appendTo(_queryBuilder);
+            }
+            return this;
+        }
+    }
+
+    public interface AddConfigurableProductsToCartArgumentsDefinition {
+        void define(AddConfigurableProductsToCartArguments args);
+    }
+
+    public MutationQuery addConfigurableProductsToCart(AddConfigurableProductsToCartOutputQueryDefinition queryDef) {
+        return addConfigurableProductsToCart(args -> {}, queryDef);
+    }
+
+    public MutationQuery addConfigurableProductsToCart(AddConfigurableProductsToCartArgumentsDefinition argsDef, AddConfigurableProductsToCartOutputQueryDefinition queryDef) {
+        startField("addConfigurableProductsToCart");
+
+        AddConfigurableProductsToCartArguments args = new AddConfigurableProductsToCartArguments(_queryBuilder);
+        argsDef.define(args);
+        AddConfigurableProductsToCartArguments.end(args);
+
+        _queryBuilder.append('{');
+        queryDef.define(new AddConfigurableProductsToCartOutputQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public class AddSimpleProductsToCartArguments extends Arguments {
+        AddSimpleProductsToCartArguments(StringBuilder _queryBuilder) {
+            super(_queryBuilder, true);
+        }
+
+        /**
+         * 
+         */
+        public AddSimpleProductsToCartArguments input(AddSimpleProductsToCartInput value) {
+            if (value != null) {
+                startArgument("input");
+                value.appendTo(_queryBuilder);
+            }
+            return this;
+        }
+    }
+
+    public interface AddSimpleProductsToCartArgumentsDefinition {
+        void define(AddSimpleProductsToCartArguments args);
+    }
+
+    public MutationQuery addSimpleProductsToCart(AddSimpleProductsToCartOutputQueryDefinition queryDef) {
+        return addSimpleProductsToCart(args -> {}, queryDef);
+    }
+
+    public MutationQuery addSimpleProductsToCart(AddSimpleProductsToCartArgumentsDefinition argsDef, AddSimpleProductsToCartOutputQueryDefinition queryDef) {
+        startField("addSimpleProductsToCart");
+
+        AddSimpleProductsToCartArguments args = new AddSimpleProductsToCartArguments(_queryBuilder);
+        argsDef.define(args);
+        AddSimpleProductsToCartArguments.end(args);
+
+        _queryBuilder.append('{');
+        queryDef.define(new AddSimpleProductsToCartOutputQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public class AddVirtualProductsToCartArguments extends Arguments {
+        AddVirtualProductsToCartArguments(StringBuilder _queryBuilder) {
+            super(_queryBuilder, true);
+        }
+
+        /**
+         * 
+         */
+        public AddVirtualProductsToCartArguments input(AddVirtualProductsToCartInput value) {
+            if (value != null) {
+                startArgument("input");
+                value.appendTo(_queryBuilder);
+            }
+            return this;
+        }
+    }
+
+    public interface AddVirtualProductsToCartArgumentsDefinition {
+        void define(AddVirtualProductsToCartArguments args);
+    }
+
+    public MutationQuery addVirtualProductsToCart(AddVirtualProductsToCartOutputQueryDefinition queryDef) {
+        return addVirtualProductsToCart(args -> {}, queryDef);
+    }
+
+    public MutationQuery addVirtualProductsToCart(AddVirtualProductsToCartArgumentsDefinition argsDef, AddVirtualProductsToCartOutputQueryDefinition queryDef) {
+        startField("addVirtualProductsToCart");
+
+        AddVirtualProductsToCartArguments args = new AddVirtualProductsToCartArguments(_queryBuilder);
+        argsDef.define(args);
+        AddVirtualProductsToCartArguments.end(args);
+
+        _queryBuilder.append('{');
+        queryDef.define(new AddVirtualProductsToCartOutputQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public class ApplyCouponToCartArguments extends Arguments {
+        ApplyCouponToCartArguments(StringBuilder _queryBuilder) {
+            super(_queryBuilder, true);
+        }
+
+        /**
+         * 
+         */
+        public ApplyCouponToCartArguments input(ApplyCouponToCartInput value) {
+            if (value != null) {
+                startArgument("input");
+                value.appendTo(_queryBuilder);
+            }
+            return this;
+        }
+    }
+
+    public interface ApplyCouponToCartArgumentsDefinition {
+        void define(ApplyCouponToCartArguments args);
+    }
+
+    public MutationQuery applyCouponToCart(ApplyCouponToCartOutputQueryDefinition queryDef) {
+        return applyCouponToCart(args -> {}, queryDef);
+    }
+
+    public MutationQuery applyCouponToCart(ApplyCouponToCartArgumentsDefinition argsDef, ApplyCouponToCartOutputQueryDefinition queryDef) {
+        startField("applyCouponToCart");
+
+        ApplyCouponToCartArguments args = new ApplyCouponToCartArguments(_queryBuilder);
+        argsDef.define(args);
+        ApplyCouponToCartArguments.end(args);
+
+        _queryBuilder.append('{');
+        queryDef.define(new ApplyCouponToCartOutputQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
     /**
      * Changes the password for the logged-in customer
      */
@@ -82,11 +238,43 @@ public class MutationQuery extends AbstractQuery<MutationQuery> {
         return this;
     }
 
+    public class CreateEmptyCartArguments extends Arguments {
+        CreateEmptyCartArguments(StringBuilder _queryBuilder) {
+            super(_queryBuilder, true);
+        }
+
+        /**
+         * 
+         */
+        public CreateEmptyCartArguments input(createEmptyCartInput value) {
+            if (value != null) {
+                startArgument("input");
+                value.appendTo(_queryBuilder);
+            }
+            return this;
+        }
+    }
+
+    public interface CreateEmptyCartArgumentsDefinition {
+        void define(CreateEmptyCartArguments args);
+    }
+
     /**
-     * Creates empty shopping cart for guest or logged in user
+     * Creates an empty shopping cart for a guest or logged in user
      */
     public MutationQuery createEmptyCart() {
+        return createEmptyCart(args -> {});
+    }
+
+    /**
+     * Creates an empty shopping cart for a guest or logged in user
+     */
+    public MutationQuery createEmptyCart(CreateEmptyCartArgumentsDefinition argsDef) {
         startField("createEmptyCart");
+
+        CreateEmptyCartArguments args = new CreateEmptyCartArguments(_queryBuilder);
+        argsDef.define(args);
+        CreateEmptyCartArguments.end(args);
 
         return this;
     }
@@ -101,6 +289,24 @@ public class MutationQuery extends AbstractQuery<MutationQuery> {
         _queryBuilder.append(id);
 
         _queryBuilder.append(')');
+
+        return this;
+    }
+
+    /**
+     * Delete a customer payment token
+     */
+    public MutationQuery deletePaymentToken(String publicHash, DeletePaymentTokenOutputQueryDefinition queryDef) {
+        startField("deletePaymentToken");
+
+        _queryBuilder.append("(public_hash:");
+        AbstractQuery.appendQuotedString(_queryBuilder, publicHash.toString());
+
+        _queryBuilder.append(')');
+
+        _queryBuilder.append('{');
+        queryDef.define(new DeletePaymentTokenOutputQuery(_queryBuilder));
+        _queryBuilder.append('}');
 
         return this;
     }
@@ -121,6 +327,123 @@ public class MutationQuery extends AbstractQuery<MutationQuery> {
 
         _queryBuilder.append('{');
         queryDef.define(new CustomerTokenQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public class PlaceOrderArguments extends Arguments {
+        PlaceOrderArguments(StringBuilder _queryBuilder) {
+            super(_queryBuilder, true);
+        }
+
+        /**
+         * 
+         */
+        public PlaceOrderArguments input(PlaceOrderInput value) {
+            if (value != null) {
+                startArgument("input");
+                value.appendTo(_queryBuilder);
+            }
+            return this;
+        }
+    }
+
+    public interface PlaceOrderArgumentsDefinition {
+        void define(PlaceOrderArguments args);
+    }
+
+    public MutationQuery placeOrder(PlaceOrderOutputQueryDefinition queryDef) {
+        return placeOrder(args -> {}, queryDef);
+    }
+
+    public MutationQuery placeOrder(PlaceOrderArgumentsDefinition argsDef, PlaceOrderOutputQueryDefinition queryDef) {
+        startField("placeOrder");
+
+        PlaceOrderArguments args = new PlaceOrderArguments(_queryBuilder);
+        argsDef.define(args);
+        PlaceOrderArguments.end(args);
+
+        _queryBuilder.append('{');
+        queryDef.define(new PlaceOrderOutputQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public class RemoveCouponFromCartArguments extends Arguments {
+        RemoveCouponFromCartArguments(StringBuilder _queryBuilder) {
+            super(_queryBuilder, true);
+        }
+
+        /**
+         * 
+         */
+        public RemoveCouponFromCartArguments input(RemoveCouponFromCartInput value) {
+            if (value != null) {
+                startArgument("input");
+                value.appendTo(_queryBuilder);
+            }
+            return this;
+        }
+    }
+
+    public interface RemoveCouponFromCartArgumentsDefinition {
+        void define(RemoveCouponFromCartArguments args);
+    }
+
+    public MutationQuery removeCouponFromCart(RemoveCouponFromCartOutputQueryDefinition queryDef) {
+        return removeCouponFromCart(args -> {}, queryDef);
+    }
+
+    public MutationQuery removeCouponFromCart(RemoveCouponFromCartArgumentsDefinition argsDef, RemoveCouponFromCartOutputQueryDefinition queryDef) {
+        startField("removeCouponFromCart");
+
+        RemoveCouponFromCartArguments args = new RemoveCouponFromCartArguments(_queryBuilder);
+        argsDef.define(args);
+        RemoveCouponFromCartArguments.end(args);
+
+        _queryBuilder.append('{');
+        queryDef.define(new RemoveCouponFromCartOutputQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public class RemoveItemFromCartArguments extends Arguments {
+        RemoveItemFromCartArguments(StringBuilder _queryBuilder) {
+            super(_queryBuilder, true);
+        }
+
+        /**
+         * 
+         */
+        public RemoveItemFromCartArguments input(RemoveItemFromCartInput value) {
+            if (value != null) {
+                startArgument("input");
+                value.appendTo(_queryBuilder);
+            }
+            return this;
+        }
+    }
+
+    public interface RemoveItemFromCartArgumentsDefinition {
+        void define(RemoveItemFromCartArguments args);
+    }
+
+    public MutationQuery removeItemFromCart(RemoveItemFromCartOutputQueryDefinition queryDef) {
+        return removeItemFromCart(args -> {}, queryDef);
+    }
+
+    public MutationQuery removeItemFromCart(RemoveItemFromCartArgumentsDefinition argsDef, RemoveItemFromCartOutputQueryDefinition queryDef) {
+        startField("removeItemFromCart");
+
+        RemoveItemFromCartArguments args = new RemoveItemFromCartArguments(_queryBuilder);
+        argsDef.define(args);
+        RemoveItemFromCartArguments.end(args);
+
+        _queryBuilder.append('{');
+        queryDef.define(new RemoveItemFromCartOutputQuery(_queryBuilder));
         _queryBuilder.append('}');
 
         return this;
@@ -179,6 +502,240 @@ public class MutationQuery extends AbstractQuery<MutationQuery> {
 
         _queryBuilder.append('{');
         queryDef.define(new SendEmailToFriendOutputQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public class SetBillingAddressOnCartArguments extends Arguments {
+        SetBillingAddressOnCartArguments(StringBuilder _queryBuilder) {
+            super(_queryBuilder, true);
+        }
+
+        /**
+         * 
+         */
+        public SetBillingAddressOnCartArguments input(SetBillingAddressOnCartInput value) {
+            if (value != null) {
+                startArgument("input");
+                value.appendTo(_queryBuilder);
+            }
+            return this;
+        }
+    }
+
+    public interface SetBillingAddressOnCartArgumentsDefinition {
+        void define(SetBillingAddressOnCartArguments args);
+    }
+
+    public MutationQuery setBillingAddressOnCart(SetBillingAddressOnCartOutputQueryDefinition queryDef) {
+        return setBillingAddressOnCart(args -> {}, queryDef);
+    }
+
+    public MutationQuery setBillingAddressOnCart(SetBillingAddressOnCartArgumentsDefinition argsDef, SetBillingAddressOnCartOutputQueryDefinition queryDef) {
+        startField("setBillingAddressOnCart");
+
+        SetBillingAddressOnCartArguments args = new SetBillingAddressOnCartArguments(_queryBuilder);
+        argsDef.define(args);
+        SetBillingAddressOnCartArguments.end(args);
+
+        _queryBuilder.append('{');
+        queryDef.define(new SetBillingAddressOnCartOutputQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public class SetGuestEmailOnCartArguments extends Arguments {
+        SetGuestEmailOnCartArguments(StringBuilder _queryBuilder) {
+            super(_queryBuilder, true);
+        }
+
+        /**
+         * 
+         */
+        public SetGuestEmailOnCartArguments input(SetGuestEmailOnCartInput value) {
+            if (value != null) {
+                startArgument("input");
+                value.appendTo(_queryBuilder);
+            }
+            return this;
+        }
+    }
+
+    public interface SetGuestEmailOnCartArgumentsDefinition {
+        void define(SetGuestEmailOnCartArguments args);
+    }
+
+    public MutationQuery setGuestEmailOnCart(SetGuestEmailOnCartOutputQueryDefinition queryDef) {
+        return setGuestEmailOnCart(args -> {}, queryDef);
+    }
+
+    public MutationQuery setGuestEmailOnCart(SetGuestEmailOnCartArgumentsDefinition argsDef, SetGuestEmailOnCartOutputQueryDefinition queryDef) {
+        startField("setGuestEmailOnCart");
+
+        SetGuestEmailOnCartArguments args = new SetGuestEmailOnCartArguments(_queryBuilder);
+        argsDef.define(args);
+        SetGuestEmailOnCartArguments.end(args);
+
+        _queryBuilder.append('{');
+        queryDef.define(new SetGuestEmailOnCartOutputQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public class SetPaymentMethodOnCartArguments extends Arguments {
+        SetPaymentMethodOnCartArguments(StringBuilder _queryBuilder) {
+            super(_queryBuilder, true);
+        }
+
+        /**
+         * 
+         */
+        public SetPaymentMethodOnCartArguments input(SetPaymentMethodOnCartInput value) {
+            if (value != null) {
+                startArgument("input");
+                value.appendTo(_queryBuilder);
+            }
+            return this;
+        }
+    }
+
+    public interface SetPaymentMethodOnCartArgumentsDefinition {
+        void define(SetPaymentMethodOnCartArguments args);
+    }
+
+    public MutationQuery setPaymentMethodOnCart(SetPaymentMethodOnCartOutputQueryDefinition queryDef) {
+        return setPaymentMethodOnCart(args -> {}, queryDef);
+    }
+
+    public MutationQuery setPaymentMethodOnCart(SetPaymentMethodOnCartArgumentsDefinition argsDef, SetPaymentMethodOnCartOutputQueryDefinition queryDef) {
+        startField("setPaymentMethodOnCart");
+
+        SetPaymentMethodOnCartArguments args = new SetPaymentMethodOnCartArguments(_queryBuilder);
+        argsDef.define(args);
+        SetPaymentMethodOnCartArguments.end(args);
+
+        _queryBuilder.append('{');
+        queryDef.define(new SetPaymentMethodOnCartOutputQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public class SetShippingAddressesOnCartArguments extends Arguments {
+        SetShippingAddressesOnCartArguments(StringBuilder _queryBuilder) {
+            super(_queryBuilder, true);
+        }
+
+        /**
+         * 
+         */
+        public SetShippingAddressesOnCartArguments input(SetShippingAddressesOnCartInput value) {
+            if (value != null) {
+                startArgument("input");
+                value.appendTo(_queryBuilder);
+            }
+            return this;
+        }
+    }
+
+    public interface SetShippingAddressesOnCartArgumentsDefinition {
+        void define(SetShippingAddressesOnCartArguments args);
+    }
+
+    public MutationQuery setShippingAddressesOnCart(SetShippingAddressesOnCartOutputQueryDefinition queryDef) {
+        return setShippingAddressesOnCart(args -> {}, queryDef);
+    }
+
+    public MutationQuery setShippingAddressesOnCart(SetShippingAddressesOnCartArgumentsDefinition argsDef, SetShippingAddressesOnCartOutputQueryDefinition queryDef) {
+        startField("setShippingAddressesOnCart");
+
+        SetShippingAddressesOnCartArguments args = new SetShippingAddressesOnCartArguments(_queryBuilder);
+        argsDef.define(args);
+        SetShippingAddressesOnCartArguments.end(args);
+
+        _queryBuilder.append('{');
+        queryDef.define(new SetShippingAddressesOnCartOutputQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public class SetShippingMethodsOnCartArguments extends Arguments {
+        SetShippingMethodsOnCartArguments(StringBuilder _queryBuilder) {
+            super(_queryBuilder, true);
+        }
+
+        /**
+         * 
+         */
+        public SetShippingMethodsOnCartArguments input(SetShippingMethodsOnCartInput value) {
+            if (value != null) {
+                startArgument("input");
+                value.appendTo(_queryBuilder);
+            }
+            return this;
+        }
+    }
+
+    public interface SetShippingMethodsOnCartArgumentsDefinition {
+        void define(SetShippingMethodsOnCartArguments args);
+    }
+
+    public MutationQuery setShippingMethodsOnCart(SetShippingMethodsOnCartOutputQueryDefinition queryDef) {
+        return setShippingMethodsOnCart(args -> {}, queryDef);
+    }
+
+    public MutationQuery setShippingMethodsOnCart(SetShippingMethodsOnCartArgumentsDefinition argsDef, SetShippingMethodsOnCartOutputQueryDefinition queryDef) {
+        startField("setShippingMethodsOnCart");
+
+        SetShippingMethodsOnCartArguments args = new SetShippingMethodsOnCartArguments(_queryBuilder);
+        argsDef.define(args);
+        SetShippingMethodsOnCartArguments.end(args);
+
+        _queryBuilder.append('{');
+        queryDef.define(new SetShippingMethodsOnCartOutputQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public class UpdateCartItemsArguments extends Arguments {
+        UpdateCartItemsArguments(StringBuilder _queryBuilder) {
+            super(_queryBuilder, true);
+        }
+
+        /**
+         * 
+         */
+        public UpdateCartItemsArguments input(UpdateCartItemsInput value) {
+            if (value != null) {
+                startArgument("input");
+                value.appendTo(_queryBuilder);
+            }
+            return this;
+        }
+    }
+
+    public interface UpdateCartItemsArgumentsDefinition {
+        void define(UpdateCartItemsArguments args);
+    }
+
+    public MutationQuery updateCartItems(UpdateCartItemsOutputQueryDefinition queryDef) {
+        return updateCartItems(args -> {}, queryDef);
+    }
+
+    public MutationQuery updateCartItems(UpdateCartItemsArgumentsDefinition argsDef, UpdateCartItemsOutputQueryDefinition queryDef) {
+        startField("updateCartItems");
+
+        UpdateCartItemsArguments args = new UpdateCartItemsArguments(_queryBuilder);
+        argsDef.define(args);
+        UpdateCartItemsArguments.end(args);
+
+        _queryBuilder.append('{');
+        queryDef.define(new UpdateCartItemsOutputQuery(_queryBuilder));
         _queryBuilder.append('}');
 
         return this;

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/Order.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/Order.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * 
+ */
+public class Order extends AbstractResponse<Order> {
+    public Order() {
+    }
+
+    public Order(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "order_id": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "Order";
+    }
+
+    public String getOrderId() {
+        return (String) get("order_id");
+    }
+
+    public Order setOrderId(String arg) {
+        optimisticData.put(getKey("order_id"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "order_id": return false;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/OrderQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/OrderQuery.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * 
+ */
+public class OrderQuery extends AbstractQuery<OrderQuery> {
+    OrderQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    public OrderQuery orderId() {
+        startField("order_id");
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/OrderQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/OrderQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface OrderQueryDefinition {
+    void define(OrderQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/PaymentMethodInput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/PaymentMethodInput.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.io.Serializable;
+
+import com.shopify.graphql.support.AbstractQuery;
+import com.shopify.graphql.support.Input;
+
+public class PaymentMethodInput implements Serializable {
+    private String code;
+
+    private Input<String> purchaseOrderNumber = Input.undefined();
+
+    public PaymentMethodInput(String code) {
+        this.code = code;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public PaymentMethodInput setCode(String code) {
+        this.code = code;
+        return this;
+    }
+
+    public String getPurchaseOrderNumber() {
+        return purchaseOrderNumber.getValue();
+    }
+
+    public Input<String> getPurchaseOrderNumberInput() {
+        return purchaseOrderNumber;
+    }
+
+    public PaymentMethodInput setPurchaseOrderNumber(String purchaseOrderNumber) {
+        this.purchaseOrderNumber = Input.optional(purchaseOrderNumber);
+        return this;
+    }
+
+    public PaymentMethodInput setPurchaseOrderNumberInput(Input<String> purchaseOrderNumber) {
+        if (purchaseOrderNumber == null) {
+            throw new IllegalArgumentException("Input can not be null");
+        }
+        this.purchaseOrderNumber = purchaseOrderNumber;
+        return this;
+    }
+
+    public void appendTo(StringBuilder _queryBuilder) {
+        String separator = "";
+        _queryBuilder.append('{');
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("code:");
+        AbstractQuery.appendQuotedString(_queryBuilder, code.toString());
+
+        if (this.purchaseOrderNumber.isDefined()) {
+            _queryBuilder.append(separator);
+            separator = ",";
+            _queryBuilder.append("purchase_order_number:");
+            if (purchaseOrderNumber.getValue() != null) {
+                AbstractQuery.appendQuotedString(_queryBuilder, purchaseOrderNumber.getValue().toString());
+            } else {
+                _queryBuilder.append("null");
+            }
+        }
+
+        _queryBuilder.append('}');
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/PaymentToken.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/PaymentToken.java
@@ -1,0 +1,142 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * The stored payment method available to the customer
+ */
+public class PaymentToken extends AbstractResponse<PaymentToken> {
+    public PaymentToken() {
+    }
+
+    public PaymentToken(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "details": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "payment_method_code": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+
+                    break;
+                }
+
+                case "public_hash": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+
+                    break;
+                }
+
+                case "type": {
+                    responseData.put(key, PaymentTokenTypeEnum.fromGraphQl(jsonAsString(field.getValue(), key)));
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "PaymentToken";
+    }
+
+    /**
+     * Stored account details
+     */
+
+    public String getDetails() {
+        return (String) get("details");
+    }
+
+    public PaymentToken setDetails(String arg) {
+        optimisticData.put(getKey("details"), arg);
+        return this;
+    }
+
+    /**
+     * The payment method code associated with the token
+     */
+
+    public String getPaymentMethodCode() {
+        return (String) get("payment_method_code");
+    }
+
+    public PaymentToken setPaymentMethodCode(String arg) {
+        optimisticData.put(getKey("payment_method_code"), arg);
+        return this;
+    }
+
+    /**
+     * The public hash of the token
+     */
+
+    public String getPublicHash() {
+        return (String) get("public_hash");
+    }
+
+    public PaymentToken setPublicHash(String arg) {
+        optimisticData.put(getKey("public_hash"), arg);
+        return this;
+    }
+
+    public PaymentTokenTypeEnum getType() {
+        return (PaymentTokenTypeEnum) get("type");
+    }
+
+    public PaymentToken setType(PaymentTokenTypeEnum arg) {
+        optimisticData.put(getKey("type"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "details": return false;
+
+            case "payment_method_code": return false;
+
+            case "public_hash": return false;
+
+            case "type": return false;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/PaymentTokenQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/PaymentTokenQuery.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * The stored payment method available to the customer
+ */
+public class PaymentTokenQuery extends AbstractQuery<PaymentTokenQuery> {
+    PaymentTokenQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    /**
+     * Stored account details
+     */
+    public PaymentTokenQuery details() {
+        startField("details");
+
+        return this;
+    }
+
+    /**
+     * The payment method code associated with the token
+     */
+    public PaymentTokenQuery paymentMethodCode() {
+        startField("payment_method_code");
+
+        return this;
+    }
+
+    /**
+     * The public hash of the token
+     */
+    public PaymentTokenQuery publicHash() {
+        startField("public_hash");
+
+        return this;
+    }
+
+    public PaymentTokenQuery type() {
+        startField("type");
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/PaymentTokenQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/PaymentTokenQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface PaymentTokenQueryDefinition {
+    void define(PaymentTokenQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/PaymentTokenTypeEnum.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/PaymentTokenTypeEnum.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+/**
+ * The list of available payment token types
+ */
+public enum PaymentTokenTypeEnum {
+    /**
+     * 
+     */
+    ACCOUNT,
+
+    /**
+     * 
+     */
+    CARD,
+
+    UNKNOWN_VALUE;
+
+    public static PaymentTokenTypeEnum fromGraphQl(String value) {
+        if (value == null) {
+            return null;
+        }
+
+        switch (value) {
+            case "account": {
+                return ACCOUNT;
+            }
+
+            case "card": {
+                return CARD;
+            }
+
+            default: {
+                return UNKNOWN_VALUE;
+            }
+        }
+    }
+    public String toString() {
+        switch (this) {
+            case ACCOUNT: {
+                return "account";
+            }
+
+            case CARD: {
+                return "card";
+            }
+
+            default: {
+                return "";
+            }
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/PlaceOrderInput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/PlaceOrderInput.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.io.Serializable;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+public class PlaceOrderInput implements Serializable {
+    private String cartId;
+
+    public PlaceOrderInput(String cartId) {
+        this.cartId = cartId;
+    }
+
+    public String getCartId() {
+        return cartId;
+    }
+
+    public PlaceOrderInput setCartId(String cartId) {
+        this.cartId = cartId;
+        return this;
+    }
+
+    public void appendTo(StringBuilder _queryBuilder) {
+        String separator = "";
+        _queryBuilder.append('{');
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("cart_id:");
+        AbstractQuery.appendQuotedString(_queryBuilder, cartId.toString());
+
+        _queryBuilder.append('}');
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/PlaceOrderOutput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/PlaceOrderOutput.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * 
+ */
+public class PlaceOrderOutput extends AbstractResponse<PlaceOrderOutput> {
+    public PlaceOrderOutput() {
+    }
+
+    public PlaceOrderOutput(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "order": {
+                    responseData.put(key, new Order(jsonAsObject(field.getValue(), key)));
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "PlaceOrderOutput";
+    }
+
+    public Order getOrder() {
+        return (Order) get("order");
+    }
+
+    public PlaceOrderOutput setOrder(Order arg) {
+        optimisticData.put(getKey("order"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "order": return true;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/PlaceOrderOutputQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/PlaceOrderOutputQuery.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * 
+ */
+public class PlaceOrderOutputQuery extends AbstractQuery<PlaceOrderOutputQuery> {
+    PlaceOrderOutputQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    public PlaceOrderOutputQuery order(OrderQueryDefinition queryDef) {
+        startField("order");
+
+        _queryBuilder.append('{');
+        queryDef.define(new OrderQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/PlaceOrderOutputQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/PlaceOrderOutputQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface PlaceOrderOutputQueryDefinition {
+    void define(PlaceOrderOutputQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/Query.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/Query.java
@@ -35,6 +35,17 @@ public class Query extends AbstractResponse<Query> {
             String key = field.getKey();
             String fieldName = getFieldName(key);
             switch (fieldName) {
+                case "cart": {
+                    Cart optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = new Cart(jsonAsObject(field.getValue(), key));
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
                 case "category": {
                     CategoryTree optional1 = null;
                     if (!field.getValue().isJsonNull()) {
@@ -155,6 +166,28 @@ public class Query extends AbstractResponse<Query> {
                     break;
                 }
 
+                case "customerPaymentTokens": {
+                    CustomerPaymentTokens optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = new CustomerPaymentTokens(jsonAsObject(field.getValue(), key));
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "isEmailAvailable": {
+                    IsEmailAvailableOutput optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = new IsEmailAvailableOutput(jsonAsObject(field.getValue(), key));
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
                 case "products": {
                     Products optional1 = null;
                     if (!field.getValue().isJsonNull()) {
@@ -213,6 +246,24 @@ public class Query extends AbstractResponse<Query> {
     public String getGraphQlTypeName() {
         return "Query";
     }
+
+    /**
+     * Returns information about shopping cart
+     */
+
+    public Cart getCart() {
+        return (Cart) get("cart");
+    }
+
+    public Query setCart(Cart arg) {
+        optimisticData.put(getKey("cart"), arg);
+        return this;
+    }
+
+    /**
+     * The category query searches for categories that match the criteria specified in the search and
+     * filter attributes
+     */
 
     public CategoryTree getCategory() {
         return (CategoryTree) get("category");
@@ -342,6 +393,28 @@ public class Query extends AbstractResponse<Query> {
     }
 
     /**
+     * Return a list of customer payment tokens
+     */
+
+    public CustomerPaymentTokens getCustomerPaymentTokens() {
+        return (CustomerPaymentTokens) get("customerPaymentTokens");
+    }
+
+    public Query setCustomerPaymentTokens(CustomerPaymentTokens arg) {
+        optimisticData.put(getKey("customerPaymentTokens"), arg);
+        return this;
+    }
+
+    public IsEmailAvailableOutput getIsEmailAvailable() {
+        return (IsEmailAvailableOutput) get("isEmailAvailable");
+    }
+
+    public Query setIsEmailAvailable(IsEmailAvailableOutput arg) {
+        optimisticData.put(getKey("isEmailAvailable"), arg);
+        return this;
+    }
+
+    /**
      * The products query searches for products that match the criteria specified in the search and filter
      * attributes
      */
@@ -396,6 +469,8 @@ public class Query extends AbstractResponse<Query> {
 
     public boolean unwrapsToObject(String key) {
         switch (getFieldName(key)) {
+            case "cart": return true;
+
             case "category": return true;
 
             case "cmsBlocks": return true;
@@ -415,6 +490,10 @@ public class Query extends AbstractResponse<Query> {
             case "customerDownloadableProducts": return true;
 
             case "customerOrders": return true;
+
+            case "customerPaymentTokens": return true;
+
+            case "isEmailAvailable": return true;
 
             case "products": return true;
 

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/QueryQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/QueryQuery.java
@@ -27,6 +27,24 @@ public class QueryQuery extends AbstractQuery<QueryQuery> {
         super(_queryBuilder);
     }
 
+    /**
+     * Returns information about shopping cart
+     */
+    public QueryQuery cart(String cartId, CartQueryDefinition queryDef) {
+        startField("cart");
+
+        _queryBuilder.append("(cart_id:");
+        AbstractQuery.appendQuotedString(_queryBuilder, cartId.toString());
+
+        _queryBuilder.append(')');
+
+        _queryBuilder.append('{');
+        queryDef.define(new CartQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
     public class CategoryArguments extends Arguments {
         CategoryArguments(StringBuilder _queryBuilder) {
             super(_queryBuilder, true);
@@ -48,10 +66,18 @@ public class QueryQuery extends AbstractQuery<QueryQuery> {
         void define(CategoryArguments args);
     }
 
+    /**
+     * The category query searches for categories that match the criteria specified in the search and
+     * filter attributes
+     */
     public QueryQuery category(CategoryTreeQueryDefinition queryDef) {
         return category(args -> {}, queryDef);
     }
 
+    /**
+     * The category query searches for categories that match the criteria specified in the search and
+     * filter attributes
+     */
     public QueryQuery category(CategoryArgumentsDefinition argsDef, CategoryTreeQueryDefinition queryDef) {
         startField("category");
 
@@ -298,6 +324,34 @@ public class QueryQuery extends AbstractQuery<QueryQuery> {
 
         _queryBuilder.append('{');
         queryDef.define(new CustomerOrdersQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    /**
+     * Return a list of customer payment tokens
+     */
+    public QueryQuery customerPaymentTokens(CustomerPaymentTokensQueryDefinition queryDef) {
+        startField("customerPaymentTokens");
+
+        _queryBuilder.append('{');
+        queryDef.define(new CustomerPaymentTokensQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public QueryQuery isEmailAvailable(String email, IsEmailAvailableOutputQueryDefinition queryDef) {
+        startField("isEmailAvailable");
+
+        _queryBuilder.append("(email:");
+        AbstractQuery.appendQuotedString(_queryBuilder, email.toString());
+
+        _queryBuilder.append(')');
+
+        _queryBuilder.append('{');
+        queryDef.define(new IsEmailAvailableOutputQuery(_queryBuilder));
         _queryBuilder.append('}');
 
         return this;

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/RemoveCouponFromCartInput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/RemoveCouponFromCartInput.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.io.Serializable;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+public class RemoveCouponFromCartInput implements Serializable {
+    private String cartId;
+
+    public RemoveCouponFromCartInput(String cartId) {
+        this.cartId = cartId;
+    }
+
+    public String getCartId() {
+        return cartId;
+    }
+
+    public RemoveCouponFromCartInput setCartId(String cartId) {
+        this.cartId = cartId;
+        return this;
+    }
+
+    public void appendTo(StringBuilder _queryBuilder) {
+        String separator = "";
+        _queryBuilder.append('{');
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("cart_id:");
+        AbstractQuery.appendQuotedString(_queryBuilder, cartId.toString());
+
+        _queryBuilder.append('}');
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/RemoveCouponFromCartOutput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/RemoveCouponFromCartOutput.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * 
+ */
+public class RemoveCouponFromCartOutput extends AbstractResponse<RemoveCouponFromCartOutput> {
+    public RemoveCouponFromCartOutput() {
+    }
+
+    public RemoveCouponFromCartOutput(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "cart": {
+                    Cart optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = new Cart(jsonAsObject(field.getValue(), key));
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "RemoveCouponFromCartOutput";
+    }
+
+    public Cart getCart() {
+        return (Cart) get("cart");
+    }
+
+    public RemoveCouponFromCartOutput setCart(Cart arg) {
+        optimisticData.put(getKey("cart"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "cart": return true;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/RemoveCouponFromCartOutputQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/RemoveCouponFromCartOutputQuery.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * 
+ */
+public class RemoveCouponFromCartOutputQuery extends AbstractQuery<RemoveCouponFromCartOutputQuery> {
+    RemoveCouponFromCartOutputQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    public RemoveCouponFromCartOutputQuery cart(CartQueryDefinition queryDef) {
+        startField("cart");
+
+        _queryBuilder.append('{');
+        queryDef.define(new CartQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/RemoveCouponFromCartOutputQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/RemoveCouponFromCartOutputQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface RemoveCouponFromCartOutputQueryDefinition {
+    void define(RemoveCouponFromCartOutputQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/RemoveItemFromCartInput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/RemoveItemFromCartInput.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.io.Serializable;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+public class RemoveItemFromCartInput implements Serializable {
+    private String cartId;
+
+    private int cartItemId;
+
+    public RemoveItemFromCartInput(String cartId, int cartItemId) {
+        this.cartId = cartId;
+
+        this.cartItemId = cartItemId;
+    }
+
+    public String getCartId() {
+        return cartId;
+    }
+
+    public RemoveItemFromCartInput setCartId(String cartId) {
+        this.cartId = cartId;
+        return this;
+    }
+
+    public int getCartItemId() {
+        return cartItemId;
+    }
+
+    public RemoveItemFromCartInput setCartItemId(int cartItemId) {
+        this.cartItemId = cartItemId;
+        return this;
+    }
+
+    public void appendTo(StringBuilder _queryBuilder) {
+        String separator = "";
+        _queryBuilder.append('{');
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("cart_id:");
+        AbstractQuery.appendQuotedString(_queryBuilder, cartId.toString());
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("cart_item_id:");
+        _queryBuilder.append(cartItemId);
+
+        _queryBuilder.append('}');
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/RemoveItemFromCartOutput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/RemoveItemFromCartOutput.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * 
+ */
+public class RemoveItemFromCartOutput extends AbstractResponse<RemoveItemFromCartOutput> {
+    public RemoveItemFromCartOutput() {
+    }
+
+    public RemoveItemFromCartOutput(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "cart": {
+                    responseData.put(key, new Cart(jsonAsObject(field.getValue(), key)));
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "RemoveItemFromCartOutput";
+    }
+
+    public Cart getCart() {
+        return (Cart) get("cart");
+    }
+
+    public RemoveItemFromCartOutput setCart(Cart arg) {
+        optimisticData.put(getKey("cart"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "cart": return true;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/RemoveItemFromCartOutputQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/RemoveItemFromCartOutputQuery.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * 
+ */
+public class RemoveItemFromCartOutputQuery extends AbstractQuery<RemoveItemFromCartOutputQuery> {
+    RemoveItemFromCartOutputQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    public RemoveItemFromCartOutputQuery cart(CartQueryDefinition queryDef) {
+        startField("cart");
+
+        _queryBuilder.append('{');
+        queryDef.define(new CartQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/RemoveItemFromCartOutputQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/RemoveItemFromCartOutputQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface RemoveItemFromCartOutputQueryDefinition {
+    void define(RemoveItemFromCartOutputQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedConfigurableOption.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedConfigurableOption.java
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * 
+ */
+public class SelectedConfigurableOption extends AbstractResponse<SelectedConfigurableOption> {
+    public SelectedConfigurableOption() {
+    }
+
+    public SelectedConfigurableOption(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "id": {
+                    responseData.put(key, jsonAsInteger(field.getValue(), key));
+
+                    break;
+                }
+
+                case "option_label": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+
+                    break;
+                }
+
+                case "value_id": {
+                    responseData.put(key, jsonAsInteger(field.getValue(), key));
+
+                    break;
+                }
+
+                case "value_label": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "SelectedConfigurableOption";
+    }
+
+    public Integer getId() {
+        return (Integer) get("id");
+    }
+
+    public SelectedConfigurableOption setId(Integer arg) {
+        optimisticData.put(getKey("id"), arg);
+        return this;
+    }
+
+    public String getOptionLabel() {
+        return (String) get("option_label");
+    }
+
+    public SelectedConfigurableOption setOptionLabel(String arg) {
+        optimisticData.put(getKey("option_label"), arg);
+        return this;
+    }
+
+    public Integer getValueId() {
+        return (Integer) get("value_id");
+    }
+
+    public SelectedConfigurableOption setValueId(Integer arg) {
+        optimisticData.put(getKey("value_id"), arg);
+        return this;
+    }
+
+    public String getValueLabel() {
+        return (String) get("value_label");
+    }
+
+    public SelectedConfigurableOption setValueLabel(String arg) {
+        optimisticData.put(getKey("value_label"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "id": return false;
+
+            case "option_label": return false;
+
+            case "value_id": return false;
+
+            case "value_label": return false;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedConfigurableOptionQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedConfigurableOptionQuery.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * 
+ */
+public class SelectedConfigurableOptionQuery extends AbstractQuery<SelectedConfigurableOptionQuery> {
+    SelectedConfigurableOptionQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    public SelectedConfigurableOptionQuery id() {
+        startField("id");
+
+        return this;
+    }
+
+    public SelectedConfigurableOptionQuery optionLabel() {
+        startField("option_label");
+
+        return this;
+    }
+
+    public SelectedConfigurableOptionQuery valueId() {
+        startField("value_id");
+
+        return this;
+    }
+
+    public SelectedConfigurableOptionQuery valueLabel() {
+        startField("value_label");
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedConfigurableOptionQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedConfigurableOptionQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface SelectedConfigurableOptionQueryDefinition {
+    void define(SelectedConfigurableOptionQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedCustomizableOption.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedCustomizableOption.java
@@ -1,0 +1,154 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * 
+ */
+public class SelectedCustomizableOption extends AbstractResponse<SelectedCustomizableOption> {
+    public SelectedCustomizableOption() {
+    }
+
+    public SelectedCustomizableOption(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "id": {
+                    responseData.put(key, jsonAsInteger(field.getValue(), key));
+
+                    break;
+                }
+
+                case "is_required": {
+                    responseData.put(key, jsonAsBoolean(field.getValue(), key));
+
+                    break;
+                }
+
+                case "label": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+
+                    break;
+                }
+
+                case "sort_order": {
+                    responseData.put(key, jsonAsInteger(field.getValue(), key));
+
+                    break;
+                }
+
+                case "values": {
+                    List<SelectedCustomizableOptionValue> list1 = new ArrayList<>();
+                    for (JsonElement element1 : jsonAsArray(field.getValue(), key)) {
+                        SelectedCustomizableOptionValue optional2 = null;
+                        if (!element1.isJsonNull()) {
+                            optional2 = new SelectedCustomizableOptionValue(jsonAsObject(element1, key));
+                        }
+
+                        list1.add(optional2);
+                    }
+
+                    responseData.put(key, list1);
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "SelectedCustomizableOption";
+    }
+
+    public Integer getId() {
+        return (Integer) get("id");
+    }
+
+    public SelectedCustomizableOption setId(Integer arg) {
+        optimisticData.put(getKey("id"), arg);
+        return this;
+    }
+
+    public Boolean getIsRequired() {
+        return (Boolean) get("is_required");
+    }
+
+    public SelectedCustomizableOption setIsRequired(Boolean arg) {
+        optimisticData.put(getKey("is_required"), arg);
+        return this;
+    }
+
+    public String getLabel() {
+        return (String) get("label");
+    }
+
+    public SelectedCustomizableOption setLabel(String arg) {
+        optimisticData.put(getKey("label"), arg);
+        return this;
+    }
+
+    public Integer getSortOrder() {
+        return (Integer) get("sort_order");
+    }
+
+    public SelectedCustomizableOption setSortOrder(Integer arg) {
+        optimisticData.put(getKey("sort_order"), arg);
+        return this;
+    }
+
+    public List<SelectedCustomizableOptionValue> getValues() {
+        return (List<SelectedCustomizableOptionValue>) get("values");
+    }
+
+    public SelectedCustomizableOption setValues(List<SelectedCustomizableOptionValue> arg) {
+        optimisticData.put(getKey("values"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "id": return false;
+
+            case "is_required": return false;
+
+            case "label": return false;
+
+            case "sort_order": return false;
+
+            case "values": return true;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedCustomizableOptionQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedCustomizableOptionQuery.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * 
+ */
+public class SelectedCustomizableOptionQuery extends AbstractQuery<SelectedCustomizableOptionQuery> {
+    SelectedCustomizableOptionQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    public SelectedCustomizableOptionQuery id() {
+        startField("id");
+
+        return this;
+    }
+
+    public SelectedCustomizableOptionQuery isRequired() {
+        startField("is_required");
+
+        return this;
+    }
+
+    public SelectedCustomizableOptionQuery label() {
+        startField("label");
+
+        return this;
+    }
+
+    public SelectedCustomizableOptionQuery sortOrder() {
+        startField("sort_order");
+
+        return this;
+    }
+
+    public SelectedCustomizableOptionQuery values(SelectedCustomizableOptionValueQueryDefinition queryDef) {
+        startField("values");
+
+        _queryBuilder.append('{');
+        queryDef.define(new SelectedCustomizableOptionValueQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedCustomizableOptionQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedCustomizableOptionQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface SelectedCustomizableOptionQueryDefinition {
+    void define(SelectedCustomizableOptionQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedCustomizableOptionValue.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedCustomizableOptionValue.java
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * 
+ */
+public class SelectedCustomizableOptionValue extends AbstractResponse<SelectedCustomizableOptionValue> {
+    public SelectedCustomizableOptionValue() {
+    }
+
+    public SelectedCustomizableOptionValue(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "id": {
+                    responseData.put(key, jsonAsInteger(field.getValue(), key));
+
+                    break;
+                }
+
+                case "label": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+
+                    break;
+                }
+
+                case "price": {
+                    responseData.put(key, new CartItemSelectedOptionValuePrice(jsonAsObject(field.getValue(), key)));
+
+                    break;
+                }
+
+                case "value": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "SelectedCustomizableOptionValue";
+    }
+
+    public Integer getId() {
+        return (Integer) get("id");
+    }
+
+    public SelectedCustomizableOptionValue setId(Integer arg) {
+        optimisticData.put(getKey("id"), arg);
+        return this;
+    }
+
+    public String getLabel() {
+        return (String) get("label");
+    }
+
+    public SelectedCustomizableOptionValue setLabel(String arg) {
+        optimisticData.put(getKey("label"), arg);
+        return this;
+    }
+
+    public CartItemSelectedOptionValuePrice getPrice() {
+        return (CartItemSelectedOptionValuePrice) get("price");
+    }
+
+    public SelectedCustomizableOptionValue setPrice(CartItemSelectedOptionValuePrice arg) {
+        optimisticData.put(getKey("price"), arg);
+        return this;
+    }
+
+    public String getValue() {
+        return (String) get("value");
+    }
+
+    public SelectedCustomizableOptionValue setValue(String arg) {
+        optimisticData.put(getKey("value"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "id": return false;
+
+            case "label": return false;
+
+            case "price": return true;
+
+            case "value": return false;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedCustomizableOptionValueQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedCustomizableOptionValueQuery.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * 
+ */
+public class SelectedCustomizableOptionValueQuery extends AbstractQuery<SelectedCustomizableOptionValueQuery> {
+    SelectedCustomizableOptionValueQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    public SelectedCustomizableOptionValueQuery id() {
+        startField("id");
+
+        return this;
+    }
+
+    public SelectedCustomizableOptionValueQuery label() {
+        startField("label");
+
+        return this;
+    }
+
+    public SelectedCustomizableOptionValueQuery price(CartItemSelectedOptionValuePriceQueryDefinition queryDef) {
+        startField("price");
+
+        _queryBuilder.append('{');
+        queryDef.define(new CartItemSelectedOptionValuePriceQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public SelectedCustomizableOptionValueQuery value() {
+        startField("value");
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedCustomizableOptionValueQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedCustomizableOptionValueQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface SelectedCustomizableOptionValueQueryDefinition {
+    void define(SelectedCustomizableOptionValueQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedPaymentMethod.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedPaymentMethod.java
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * 
+ */
+public class SelectedPaymentMethod extends AbstractResponse<SelectedPaymentMethod> {
+    public SelectedPaymentMethod() {
+    }
+
+    public SelectedPaymentMethod(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "code": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+
+                    break;
+                }
+
+                case "purchase_order_number": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "title": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "SelectedPaymentMethod";
+    }
+
+    /**
+     * The payment method code
+     */
+
+    public String getCode() {
+        return (String) get("code");
+    }
+
+    public SelectedPaymentMethod setCode(String arg) {
+        optimisticData.put(getKey("code"), arg);
+        return this;
+    }
+
+    /**
+     * The purchase order number.
+     */
+
+    public String getPurchaseOrderNumber() {
+        return (String) get("purchase_order_number");
+    }
+
+    public SelectedPaymentMethod setPurchaseOrderNumber(String arg) {
+        optimisticData.put(getKey("purchase_order_number"), arg);
+        return this;
+    }
+
+    /**
+     * The payment method title.
+     */
+
+    public String getTitle() {
+        return (String) get("title");
+    }
+
+    public SelectedPaymentMethod setTitle(String arg) {
+        optimisticData.put(getKey("title"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "code": return false;
+
+            case "purchase_order_number": return false;
+
+            case "title": return false;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedPaymentMethodQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedPaymentMethodQuery.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * 
+ */
+public class SelectedPaymentMethodQuery extends AbstractQuery<SelectedPaymentMethodQuery> {
+    SelectedPaymentMethodQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    /**
+     * The payment method code
+     */
+    public SelectedPaymentMethodQuery code() {
+        startField("code");
+
+        return this;
+    }
+
+    /**
+     * The purchase order number.
+     */
+    public SelectedPaymentMethodQuery purchaseOrderNumber() {
+        startField("purchase_order_number");
+
+        return this;
+    }
+
+    /**
+     * The payment method title.
+     */
+    public SelectedPaymentMethodQuery title() {
+        startField("title");
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedPaymentMethodQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedPaymentMethodQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface SelectedPaymentMethodQueryDefinition {
+    void define(SelectedPaymentMethodQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedShippingMethod.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedShippingMethod.java
@@ -1,0 +1,189 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * 
+ */
+public class SelectedShippingMethod extends AbstractResponse<SelectedShippingMethod> {
+    public SelectedShippingMethod() {
+    }
+
+    public SelectedShippingMethod(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "amount": {
+                    Money optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = new Money(jsonAsObject(field.getValue(), key));
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "base_amount": {
+                    Money optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = new Money(jsonAsObject(field.getValue(), key));
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "carrier_code": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "carrier_title": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "method_code": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "method_title": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "SelectedShippingMethod";
+    }
+
+    public Money getAmount() {
+        return (Money) get("amount");
+    }
+
+    public SelectedShippingMethod setAmount(Money arg) {
+        optimisticData.put(getKey("amount"), arg);
+        return this;
+    }
+
+    public Money getBaseAmount() {
+        return (Money) get("base_amount");
+    }
+
+    public SelectedShippingMethod setBaseAmount(Money arg) {
+        optimisticData.put(getKey("base_amount"), arg);
+        return this;
+    }
+
+    public String getCarrierCode() {
+        return (String) get("carrier_code");
+    }
+
+    public SelectedShippingMethod setCarrierCode(String arg) {
+        optimisticData.put(getKey("carrier_code"), arg);
+        return this;
+    }
+
+    public String getCarrierTitle() {
+        return (String) get("carrier_title");
+    }
+
+    public SelectedShippingMethod setCarrierTitle(String arg) {
+        optimisticData.put(getKey("carrier_title"), arg);
+        return this;
+    }
+
+    public String getMethodCode() {
+        return (String) get("method_code");
+    }
+
+    public SelectedShippingMethod setMethodCode(String arg) {
+        optimisticData.put(getKey("method_code"), arg);
+        return this;
+    }
+
+    public String getMethodTitle() {
+        return (String) get("method_title");
+    }
+
+    public SelectedShippingMethod setMethodTitle(String arg) {
+        optimisticData.put(getKey("method_title"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "amount": return true;
+
+            case "base_amount": return true;
+
+            case "carrier_code": return false;
+
+            case "carrier_title": return false;
+
+            case "method_code": return false;
+
+            case "method_title": return false;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedShippingMethodQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedShippingMethodQuery.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * 
+ */
+public class SelectedShippingMethodQuery extends AbstractQuery<SelectedShippingMethodQuery> {
+    SelectedShippingMethodQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    public SelectedShippingMethodQuery amount(MoneyQueryDefinition queryDef) {
+        startField("amount");
+
+        _queryBuilder.append('{');
+        queryDef.define(new MoneyQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public SelectedShippingMethodQuery baseAmount(MoneyQueryDefinition queryDef) {
+        startField("base_amount");
+
+        _queryBuilder.append('{');
+        queryDef.define(new MoneyQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public SelectedShippingMethodQuery carrierCode() {
+        startField("carrier_code");
+
+        return this;
+    }
+
+    public SelectedShippingMethodQuery carrierTitle() {
+        startField("carrier_title");
+
+        return this;
+    }
+
+    public SelectedShippingMethodQuery methodCode() {
+        startField("method_code");
+
+        return this;
+    }
+
+    public SelectedShippingMethodQuery methodTitle() {
+        startField("method_title");
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedShippingMethodQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedShippingMethodQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface SelectedShippingMethodQueryDefinition {
+    void define(SelectedShippingMethodQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SetBillingAddressOnCartInput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SetBillingAddressOnCartInput.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.io.Serializable;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+public class SetBillingAddressOnCartInput implements Serializable {
+    private BillingAddressInput billingAddress;
+
+    private String cartId;
+
+    public SetBillingAddressOnCartInput(BillingAddressInput billingAddress, String cartId) {
+        this.billingAddress = billingAddress;
+
+        this.cartId = cartId;
+    }
+
+    public BillingAddressInput getBillingAddress() {
+        return billingAddress;
+    }
+
+    public SetBillingAddressOnCartInput setBillingAddress(BillingAddressInput billingAddress) {
+        this.billingAddress = billingAddress;
+        return this;
+    }
+
+    public String getCartId() {
+        return cartId;
+    }
+
+    public SetBillingAddressOnCartInput setCartId(String cartId) {
+        this.cartId = cartId;
+        return this;
+    }
+
+    public void appendTo(StringBuilder _queryBuilder) {
+        String separator = "";
+        _queryBuilder.append('{');
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("billing_address:");
+        billingAddress.appendTo(_queryBuilder);
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("cart_id:");
+        AbstractQuery.appendQuotedString(_queryBuilder, cartId.toString());
+
+        _queryBuilder.append('}');
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SetBillingAddressOnCartOutput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SetBillingAddressOnCartOutput.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * 
+ */
+public class SetBillingAddressOnCartOutput extends AbstractResponse<SetBillingAddressOnCartOutput> {
+    public SetBillingAddressOnCartOutput() {
+    }
+
+    public SetBillingAddressOnCartOutput(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "cart": {
+                    responseData.put(key, new Cart(jsonAsObject(field.getValue(), key)));
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "SetBillingAddressOnCartOutput";
+    }
+
+    public Cart getCart() {
+        return (Cart) get("cart");
+    }
+
+    public SetBillingAddressOnCartOutput setCart(Cart arg) {
+        optimisticData.put(getKey("cart"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "cart": return true;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SetBillingAddressOnCartOutputQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SetBillingAddressOnCartOutputQuery.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * 
+ */
+public class SetBillingAddressOnCartOutputQuery extends AbstractQuery<SetBillingAddressOnCartOutputQuery> {
+    SetBillingAddressOnCartOutputQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    public SetBillingAddressOnCartOutputQuery cart(CartQueryDefinition queryDef) {
+        startField("cart");
+
+        _queryBuilder.append('{');
+        queryDef.define(new CartQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SetBillingAddressOnCartOutputQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SetBillingAddressOnCartOutputQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface SetBillingAddressOnCartOutputQueryDefinition {
+    void define(SetBillingAddressOnCartOutputQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SetGuestEmailOnCartInput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SetGuestEmailOnCartInput.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.io.Serializable;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+public class SetGuestEmailOnCartInput implements Serializable {
+    private String cartId;
+
+    private String email;
+
+    public SetGuestEmailOnCartInput(String cartId, String email) {
+        this.cartId = cartId;
+
+        this.email = email;
+    }
+
+    public String getCartId() {
+        return cartId;
+    }
+
+    public SetGuestEmailOnCartInput setCartId(String cartId) {
+        this.cartId = cartId;
+        return this;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public SetGuestEmailOnCartInput setEmail(String email) {
+        this.email = email;
+        return this;
+    }
+
+    public void appendTo(StringBuilder _queryBuilder) {
+        String separator = "";
+        _queryBuilder.append('{');
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("cart_id:");
+        AbstractQuery.appendQuotedString(_queryBuilder, cartId.toString());
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("email:");
+        AbstractQuery.appendQuotedString(_queryBuilder, email.toString());
+
+        _queryBuilder.append('}');
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SetGuestEmailOnCartOutput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SetGuestEmailOnCartOutput.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * 
+ */
+public class SetGuestEmailOnCartOutput extends AbstractResponse<SetGuestEmailOnCartOutput> {
+    public SetGuestEmailOnCartOutput() {
+    }
+
+    public SetGuestEmailOnCartOutput(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "cart": {
+                    responseData.put(key, new Cart(jsonAsObject(field.getValue(), key)));
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "SetGuestEmailOnCartOutput";
+    }
+
+    public Cart getCart() {
+        return (Cart) get("cart");
+    }
+
+    public SetGuestEmailOnCartOutput setCart(Cart arg) {
+        optimisticData.put(getKey("cart"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "cart": return true;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SetGuestEmailOnCartOutputQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SetGuestEmailOnCartOutputQuery.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * 
+ */
+public class SetGuestEmailOnCartOutputQuery extends AbstractQuery<SetGuestEmailOnCartOutputQuery> {
+    SetGuestEmailOnCartOutputQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    public SetGuestEmailOnCartOutputQuery cart(CartQueryDefinition queryDef) {
+        startField("cart");
+
+        _queryBuilder.append('{');
+        queryDef.define(new CartQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SetGuestEmailOnCartOutputQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SetGuestEmailOnCartOutputQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface SetGuestEmailOnCartOutputQueryDefinition {
+    void define(SetGuestEmailOnCartOutputQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SetPaymentMethodOnCartInput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SetPaymentMethodOnCartInput.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.io.Serializable;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+public class SetPaymentMethodOnCartInput implements Serializable {
+    private String cartId;
+
+    private PaymentMethodInput paymentMethod;
+
+    public SetPaymentMethodOnCartInput(String cartId, PaymentMethodInput paymentMethod) {
+        this.cartId = cartId;
+
+        this.paymentMethod = paymentMethod;
+    }
+
+    public String getCartId() {
+        return cartId;
+    }
+
+    public SetPaymentMethodOnCartInput setCartId(String cartId) {
+        this.cartId = cartId;
+        return this;
+    }
+
+    public PaymentMethodInput getPaymentMethod() {
+        return paymentMethod;
+    }
+
+    public SetPaymentMethodOnCartInput setPaymentMethod(PaymentMethodInput paymentMethod) {
+        this.paymentMethod = paymentMethod;
+        return this;
+    }
+
+    public void appendTo(StringBuilder _queryBuilder) {
+        String separator = "";
+        _queryBuilder.append('{');
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("cart_id:");
+        AbstractQuery.appendQuotedString(_queryBuilder, cartId.toString());
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("payment_method:");
+        paymentMethod.appendTo(_queryBuilder);
+
+        _queryBuilder.append('}');
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SetPaymentMethodOnCartOutput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SetPaymentMethodOnCartOutput.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * 
+ */
+public class SetPaymentMethodOnCartOutput extends AbstractResponse<SetPaymentMethodOnCartOutput> {
+    public SetPaymentMethodOnCartOutput() {
+    }
+
+    public SetPaymentMethodOnCartOutput(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "cart": {
+                    responseData.put(key, new Cart(jsonAsObject(field.getValue(), key)));
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "SetPaymentMethodOnCartOutput";
+    }
+
+    public Cart getCart() {
+        return (Cart) get("cart");
+    }
+
+    public SetPaymentMethodOnCartOutput setCart(Cart arg) {
+        optimisticData.put(getKey("cart"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "cart": return true;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SetPaymentMethodOnCartOutputQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SetPaymentMethodOnCartOutputQuery.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * 
+ */
+public class SetPaymentMethodOnCartOutputQuery extends AbstractQuery<SetPaymentMethodOnCartOutputQuery> {
+    SetPaymentMethodOnCartOutputQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    public SetPaymentMethodOnCartOutputQuery cart(CartQueryDefinition queryDef) {
+        startField("cart");
+
+        _queryBuilder.append('{');
+        queryDef.define(new CartQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SetPaymentMethodOnCartOutputQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SetPaymentMethodOnCartOutputQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface SetPaymentMethodOnCartOutputQueryDefinition {
+    void define(SetPaymentMethodOnCartOutputQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SetShippingAddressesOnCartInput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SetShippingAddressesOnCartInput.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.io.Serializable;
+import java.util.List;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+public class SetShippingAddressesOnCartInput implements Serializable {
+    private String cartId;
+
+    private List<ShippingAddressInput> shippingAddresses;
+
+    public SetShippingAddressesOnCartInput(String cartId, List<ShippingAddressInput> shippingAddresses) {
+        this.cartId = cartId;
+
+        this.shippingAddresses = shippingAddresses;
+    }
+
+    public String getCartId() {
+        return cartId;
+    }
+
+    public SetShippingAddressesOnCartInput setCartId(String cartId) {
+        this.cartId = cartId;
+        return this;
+    }
+
+    public List<ShippingAddressInput> getShippingAddresses() {
+        return shippingAddresses;
+    }
+
+    public SetShippingAddressesOnCartInput setShippingAddresses(List<ShippingAddressInput> shippingAddresses) {
+        this.shippingAddresses = shippingAddresses;
+        return this;
+    }
+
+    public void appendTo(StringBuilder _queryBuilder) {
+        String separator = "";
+        _queryBuilder.append('{');
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("cart_id:");
+        AbstractQuery.appendQuotedString(_queryBuilder, cartId.toString());
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("shipping_addresses:");
+        _queryBuilder.append('[');
+        {
+            String listSeperator1 = "";
+            for (ShippingAddressInput item1 : shippingAddresses) {
+                _queryBuilder.append(listSeperator1);
+                listSeperator1 = ",";
+                item1.appendTo(_queryBuilder);
+            }
+        }
+        _queryBuilder.append(']');
+
+        _queryBuilder.append('}');
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SetShippingAddressesOnCartOutput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SetShippingAddressesOnCartOutput.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * 
+ */
+public class SetShippingAddressesOnCartOutput extends AbstractResponse<SetShippingAddressesOnCartOutput> {
+    public SetShippingAddressesOnCartOutput() {
+    }
+
+    public SetShippingAddressesOnCartOutput(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "cart": {
+                    responseData.put(key, new Cart(jsonAsObject(field.getValue(), key)));
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "SetShippingAddressesOnCartOutput";
+    }
+
+    public Cart getCart() {
+        return (Cart) get("cart");
+    }
+
+    public SetShippingAddressesOnCartOutput setCart(Cart arg) {
+        optimisticData.put(getKey("cart"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "cart": return true;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SetShippingAddressesOnCartOutputQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SetShippingAddressesOnCartOutputQuery.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * 
+ */
+public class SetShippingAddressesOnCartOutputQuery extends AbstractQuery<SetShippingAddressesOnCartOutputQuery> {
+    SetShippingAddressesOnCartOutputQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    public SetShippingAddressesOnCartOutputQuery cart(CartQueryDefinition queryDef) {
+        startField("cart");
+
+        _queryBuilder.append('{');
+        queryDef.define(new CartQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SetShippingAddressesOnCartOutputQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SetShippingAddressesOnCartOutputQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface SetShippingAddressesOnCartOutputQueryDefinition {
+    void define(SetShippingAddressesOnCartOutputQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SetShippingMethodsOnCartInput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SetShippingMethodsOnCartInput.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.io.Serializable;
+import java.util.List;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+public class SetShippingMethodsOnCartInput implements Serializable {
+    private String cartId;
+
+    private List<ShippingMethodInput> shippingMethods;
+
+    public SetShippingMethodsOnCartInput(String cartId, List<ShippingMethodInput> shippingMethods) {
+        this.cartId = cartId;
+
+        this.shippingMethods = shippingMethods;
+    }
+
+    public String getCartId() {
+        return cartId;
+    }
+
+    public SetShippingMethodsOnCartInput setCartId(String cartId) {
+        this.cartId = cartId;
+        return this;
+    }
+
+    public List<ShippingMethodInput> getShippingMethods() {
+        return shippingMethods;
+    }
+
+    public SetShippingMethodsOnCartInput setShippingMethods(List<ShippingMethodInput> shippingMethods) {
+        this.shippingMethods = shippingMethods;
+        return this;
+    }
+
+    public void appendTo(StringBuilder _queryBuilder) {
+        String separator = "";
+        _queryBuilder.append('{');
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("cart_id:");
+        AbstractQuery.appendQuotedString(_queryBuilder, cartId.toString());
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("shipping_methods:");
+        _queryBuilder.append('[');
+        {
+            String listSeperator1 = "";
+            for (ShippingMethodInput item1 : shippingMethods) {
+                _queryBuilder.append(listSeperator1);
+                listSeperator1 = ",";
+                item1.appendTo(_queryBuilder);
+            }
+        }
+        _queryBuilder.append(']');
+
+        _queryBuilder.append('}');
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SetShippingMethodsOnCartOutput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SetShippingMethodsOnCartOutput.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * 
+ */
+public class SetShippingMethodsOnCartOutput extends AbstractResponse<SetShippingMethodsOnCartOutput> {
+    public SetShippingMethodsOnCartOutput() {
+    }
+
+    public SetShippingMethodsOnCartOutput(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "cart": {
+                    responseData.put(key, new Cart(jsonAsObject(field.getValue(), key)));
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "SetShippingMethodsOnCartOutput";
+    }
+
+    public Cart getCart() {
+        return (Cart) get("cart");
+    }
+
+    public SetShippingMethodsOnCartOutput setCart(Cart arg) {
+        optimisticData.put(getKey("cart"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "cart": return true;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SetShippingMethodsOnCartOutputQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SetShippingMethodsOnCartOutputQuery.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * 
+ */
+public class SetShippingMethodsOnCartOutputQuery extends AbstractQuery<SetShippingMethodsOnCartOutputQuery> {
+    SetShippingMethodsOnCartOutputQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    public SetShippingMethodsOnCartOutputQuery cart(CartQueryDefinition queryDef) {
+        startField("cart");
+
+        _queryBuilder.append('{');
+        queryDef.define(new CartQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SetShippingMethodsOnCartOutputQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SetShippingMethodsOnCartOutputQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface SetShippingMethodsOnCartOutputQueryDefinition {
+    void define(SetShippingMethodsOnCartOutputQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/ShippingAddressInput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/ShippingAddressInput.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.io.Serializable;
+
+import com.shopify.graphql.support.Input;
+
+public class ShippingAddressInput implements Serializable {
+    private Input<CartAddressInput> address = Input.undefined();
+
+    private Input<Integer> customerAddressId = Input.undefined();
+
+    public CartAddressInput getAddress() {
+        return address.getValue();
+    }
+
+    public Input<CartAddressInput> getAddressInput() {
+        return address;
+    }
+
+    public ShippingAddressInput setAddress(CartAddressInput address) {
+        this.address = Input.optional(address);
+        return this;
+    }
+
+    public ShippingAddressInput setAddressInput(Input<CartAddressInput> address) {
+        if (address == null) {
+            throw new IllegalArgumentException("Input can not be null");
+        }
+        this.address = address;
+        return this;
+    }
+
+    public Integer getCustomerAddressId() {
+        return customerAddressId.getValue();
+    }
+
+    public Input<Integer> getCustomerAddressIdInput() {
+        return customerAddressId;
+    }
+
+    public ShippingAddressInput setCustomerAddressId(Integer customerAddressId) {
+        this.customerAddressId = Input.optional(customerAddressId);
+        return this;
+    }
+
+    public ShippingAddressInput setCustomerAddressIdInput(Input<Integer> customerAddressId) {
+        if (customerAddressId == null) {
+            throw new IllegalArgumentException("Input can not be null");
+        }
+        this.customerAddressId = customerAddressId;
+        return this;
+    }
+
+    public void appendTo(StringBuilder _queryBuilder) {
+        String separator = "";
+        _queryBuilder.append('{');
+
+        if (this.address.isDefined()) {
+            _queryBuilder.append(separator);
+            separator = ",";
+            _queryBuilder.append("address:");
+            if (address.getValue() != null) {
+                address.getValue().appendTo(_queryBuilder);
+            } else {
+                _queryBuilder.append("null");
+            }
+        }
+
+        if (this.customerAddressId.isDefined()) {
+            _queryBuilder.append(separator);
+            separator = ",";
+            _queryBuilder.append("customer_address_id:");
+            if (customerAddressId.getValue() != null) {
+                _queryBuilder.append(customerAddressId.getValue());
+            } else {
+                _queryBuilder.append("null");
+            }
+        }
+
+        _queryBuilder.append('}');
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/ShippingCartAddress.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/ShippingCartAddress.java
@@ -1,0 +1,397 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * 
+ */
+public class ShippingCartAddress extends AbstractResponse<ShippingCartAddress> implements CartAddressInterface {
+    public ShippingCartAddress() {
+    }
+
+    public ShippingCartAddress(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "available_shipping_methods": {
+                    List<AvailableShippingMethod> optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        List<AvailableShippingMethod> list1 = new ArrayList<>();
+                        for (JsonElement element1 : jsonAsArray(field.getValue(), key)) {
+                            AvailableShippingMethod optional2 = null;
+                            if (!element1.isJsonNull()) {
+                                optional2 = new AvailableShippingMethod(jsonAsObject(element1, key));
+                            }
+
+                            list1.add(optional2);
+                        }
+
+                        optional1 = list1;
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "cart_items": {
+                    List<CartItemQuantity> optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        List<CartItemQuantity> list1 = new ArrayList<>();
+                        for (JsonElement element1 : jsonAsArray(field.getValue(), key)) {
+                            CartItemQuantity optional2 = null;
+                            if (!element1.isJsonNull()) {
+                                optional2 = new CartItemQuantity(jsonAsObject(element1, key));
+                            }
+
+                            list1.add(optional2);
+                        }
+
+                        optional1 = list1;
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "city": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "company": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "country": {
+                    CartAddressCountry optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = new CartAddressCountry(jsonAsObject(field.getValue(), key));
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "customer_notes": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "firstname": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "items_weight": {
+                    Double optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsDouble(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "lastname": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "postcode": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "region": {
+                    CartAddressRegion optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = new CartAddressRegion(jsonAsObject(field.getValue(), key));
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "selected_shipping_method": {
+                    SelectedShippingMethod optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = new SelectedShippingMethod(jsonAsObject(field.getValue(), key));
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "street": {
+                    List<String> optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        List<String> list1 = new ArrayList<>();
+                        for (JsonElement element1 : jsonAsArray(field.getValue(), key)) {
+                            String optional2 = null;
+                            if (!element1.isJsonNull()) {
+                                optional2 = jsonAsString(element1, key);
+                            }
+
+                            list1.add(optional2);
+                        }
+
+                        optional1 = list1;
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "telephone": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "ShippingCartAddress";
+    }
+
+    public List<AvailableShippingMethod> getAvailableShippingMethods() {
+        return (List<AvailableShippingMethod>) get("available_shipping_methods");
+    }
+
+    public ShippingCartAddress setAvailableShippingMethods(List<AvailableShippingMethod> arg) {
+        optimisticData.put(getKey("available_shipping_methods"), arg);
+        return this;
+    }
+
+    public List<CartItemQuantity> getCartItems() {
+        return (List<CartItemQuantity>) get("cart_items");
+    }
+
+    public ShippingCartAddress setCartItems(List<CartItemQuantity> arg) {
+        optimisticData.put(getKey("cart_items"), arg);
+        return this;
+    }
+
+    public String getCity() {
+        return (String) get("city");
+    }
+
+    public ShippingCartAddress setCity(String arg) {
+        optimisticData.put(getKey("city"), arg);
+        return this;
+    }
+
+    public String getCompany() {
+        return (String) get("company");
+    }
+
+    public ShippingCartAddress setCompany(String arg) {
+        optimisticData.put(getKey("company"), arg);
+        return this;
+    }
+
+    public CartAddressCountry getCountry() {
+        return (CartAddressCountry) get("country");
+    }
+
+    public ShippingCartAddress setCountry(CartAddressCountry arg) {
+        optimisticData.put(getKey("country"), arg);
+        return this;
+    }
+
+    public String getCustomerNotes() {
+        return (String) get("customer_notes");
+    }
+
+    public ShippingCartAddress setCustomerNotes(String arg) {
+        optimisticData.put(getKey("customer_notes"), arg);
+        return this;
+    }
+
+    public String getFirstname() {
+        return (String) get("firstname");
+    }
+
+    public ShippingCartAddress setFirstname(String arg) {
+        optimisticData.put(getKey("firstname"), arg);
+        return this;
+    }
+
+    public Double getItemsWeight() {
+        return (Double) get("items_weight");
+    }
+
+    public ShippingCartAddress setItemsWeight(Double arg) {
+        optimisticData.put(getKey("items_weight"), arg);
+        return this;
+    }
+
+    public String getLastname() {
+        return (String) get("lastname");
+    }
+
+    public ShippingCartAddress setLastname(String arg) {
+        optimisticData.put(getKey("lastname"), arg);
+        return this;
+    }
+
+    public String getPostcode() {
+        return (String) get("postcode");
+    }
+
+    public ShippingCartAddress setPostcode(String arg) {
+        optimisticData.put(getKey("postcode"), arg);
+        return this;
+    }
+
+    public CartAddressRegion getRegion() {
+        return (CartAddressRegion) get("region");
+    }
+
+    public ShippingCartAddress setRegion(CartAddressRegion arg) {
+        optimisticData.put(getKey("region"), arg);
+        return this;
+    }
+
+    public SelectedShippingMethod getSelectedShippingMethod() {
+        return (SelectedShippingMethod) get("selected_shipping_method");
+    }
+
+    public ShippingCartAddress setSelectedShippingMethod(SelectedShippingMethod arg) {
+        optimisticData.put(getKey("selected_shipping_method"), arg);
+        return this;
+    }
+
+    public List<String> getStreet() {
+        return (List<String>) get("street");
+    }
+
+    public ShippingCartAddress setStreet(List<String> arg) {
+        optimisticData.put(getKey("street"), arg);
+        return this;
+    }
+
+    public String getTelephone() {
+        return (String) get("telephone");
+    }
+
+    public ShippingCartAddress setTelephone(String arg) {
+        optimisticData.put(getKey("telephone"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "available_shipping_methods": return true;
+
+            case "cart_items": return true;
+
+            case "city": return false;
+
+            case "company": return false;
+
+            case "country": return true;
+
+            case "customer_notes": return false;
+
+            case "firstname": return false;
+
+            case "items_weight": return false;
+
+            case "lastname": return false;
+
+            case "postcode": return false;
+
+            case "region": return true;
+
+            case "selected_shipping_method": return true;
+
+            case "street": return false;
+
+            case "telephone": return false;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/ShippingCartAddressQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/ShippingCartAddressQuery.java
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * 
+ */
+public class ShippingCartAddressQuery extends AbstractQuery<ShippingCartAddressQuery> {
+    ShippingCartAddressQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    public ShippingCartAddressQuery availableShippingMethods(AvailableShippingMethodQueryDefinition queryDef) {
+        startField("available_shipping_methods");
+
+        _queryBuilder.append('{');
+        queryDef.define(new AvailableShippingMethodQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public ShippingCartAddressQuery cartItems(CartItemQuantityQueryDefinition queryDef) {
+        startField("cart_items");
+
+        _queryBuilder.append('{');
+        queryDef.define(new CartItemQuantityQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public ShippingCartAddressQuery city() {
+        startField("city");
+
+        return this;
+    }
+
+    public ShippingCartAddressQuery company() {
+        startField("company");
+
+        return this;
+    }
+
+    public ShippingCartAddressQuery country(CartAddressCountryQueryDefinition queryDef) {
+        startField("country");
+
+        _queryBuilder.append('{');
+        queryDef.define(new CartAddressCountryQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public ShippingCartAddressQuery customerNotes() {
+        startField("customer_notes");
+
+        return this;
+    }
+
+    public ShippingCartAddressQuery firstname() {
+        startField("firstname");
+
+        return this;
+    }
+
+    public ShippingCartAddressQuery itemsWeight() {
+        startField("items_weight");
+
+        return this;
+    }
+
+    public ShippingCartAddressQuery lastname() {
+        startField("lastname");
+
+        return this;
+    }
+
+    public ShippingCartAddressQuery postcode() {
+        startField("postcode");
+
+        return this;
+    }
+
+    public ShippingCartAddressQuery region(CartAddressRegionQueryDefinition queryDef) {
+        startField("region");
+
+        _queryBuilder.append('{');
+        queryDef.define(new CartAddressRegionQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public ShippingCartAddressQuery selectedShippingMethod(SelectedShippingMethodQueryDefinition queryDef) {
+        startField("selected_shipping_method");
+
+        _queryBuilder.append('{');
+        queryDef.define(new SelectedShippingMethodQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public ShippingCartAddressQuery street() {
+        startField("street");
+
+        return this;
+    }
+
+    public ShippingCartAddressQuery telephone() {
+        startField("telephone");
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/ShippingCartAddressQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/ShippingCartAddressQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface ShippingCartAddressQueryDefinition {
+    void define(ShippingCartAddressQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/ShippingMethodInput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/ShippingMethodInput.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.io.Serializable;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+public class ShippingMethodInput implements Serializable {
+    private String carrierCode;
+
+    private String methodCode;
+
+    public ShippingMethodInput(String carrierCode, String methodCode) {
+        this.carrierCode = carrierCode;
+
+        this.methodCode = methodCode;
+    }
+
+    public String getCarrierCode() {
+        return carrierCode;
+    }
+
+    public ShippingMethodInput setCarrierCode(String carrierCode) {
+        this.carrierCode = carrierCode;
+        return this;
+    }
+
+    public String getMethodCode() {
+        return methodCode;
+    }
+
+    public ShippingMethodInput setMethodCode(String methodCode) {
+        this.methodCode = methodCode;
+        return this;
+    }
+
+    public void appendTo(StringBuilder _queryBuilder) {
+        String separator = "";
+        _queryBuilder.append('{');
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("carrier_code:");
+        AbstractQuery.appendQuotedString(_queryBuilder, carrierCode.toString());
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("method_code:");
+        AbstractQuery.appendQuotedString(_queryBuilder, methodCode.toString());
+
+        _queryBuilder.append('}');
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SimpleCartItem.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SimpleCartItem.java
@@ -1,0 +1,142 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * Simple Cart Item
+ */
+public class SimpleCartItem extends AbstractResponse<SimpleCartItem> implements CartItemInterface {
+    public SimpleCartItem() {
+    }
+
+    public SimpleCartItem(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "customizable_options": {
+                    List<SelectedCustomizableOption> optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        List<SelectedCustomizableOption> list1 = new ArrayList<>();
+                        for (JsonElement element1 : jsonAsArray(field.getValue(), key)) {
+                            SelectedCustomizableOption optional2 = null;
+                            if (!element1.isJsonNull()) {
+                                optional2 = new SelectedCustomizableOption(jsonAsObject(element1, key));
+                            }
+
+                            list1.add(optional2);
+                        }
+
+                        optional1 = list1;
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "id": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+
+                    break;
+                }
+
+                case "product": {
+                    responseData.put(key, UnknownProductInterface.create(jsonAsObject(field.getValue(), key)));
+
+                    break;
+                }
+
+                case "quantity": {
+                    responseData.put(key, jsonAsDouble(field.getValue(), key));
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "SimpleCartItem";
+    }
+
+    public List<SelectedCustomizableOption> getCustomizableOptions() {
+        return (List<SelectedCustomizableOption>) get("customizable_options");
+    }
+
+    public SimpleCartItem setCustomizableOptions(List<SelectedCustomizableOption> arg) {
+        optimisticData.put(getKey("customizable_options"), arg);
+        return this;
+    }
+
+    public String getId() {
+        return (String) get("id");
+    }
+
+    public SimpleCartItem setId(String arg) {
+        optimisticData.put(getKey("id"), arg);
+        return this;
+    }
+
+    public ProductInterface getProduct() {
+        return (ProductInterface) get("product");
+    }
+
+    public SimpleCartItem setProduct(ProductInterface arg) {
+        optimisticData.put(getKey("product"), arg);
+        return this;
+    }
+
+    public Double getQuantity() {
+        return (Double) get("quantity");
+    }
+
+    public SimpleCartItem setQuantity(Double arg) {
+        optimisticData.put(getKey("quantity"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "customizable_options": return true;
+
+            case "id": return false;
+
+            case "product": return false;
+
+            case "quantity": return false;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SimpleCartItemQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SimpleCartItemQuery.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * Simple Cart Item
+ */
+public class SimpleCartItemQuery extends AbstractQuery<SimpleCartItemQuery> {
+    SimpleCartItemQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    public SimpleCartItemQuery customizableOptions(SelectedCustomizableOptionQueryDefinition queryDef) {
+        startField("customizable_options");
+
+        _queryBuilder.append('{');
+        queryDef.define(new SelectedCustomizableOptionQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public SimpleCartItemQuery id() {
+        startField("id");
+
+        return this;
+    }
+
+    public SimpleCartItemQuery product(ProductInterfaceQueryDefinition queryDef) {
+        startField("product");
+
+        _queryBuilder.append('{');
+        queryDef.define(new ProductInterfaceQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public SimpleCartItemQuery quantity() {
+        startField("quantity");
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SimpleCartItemQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SimpleCartItemQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface SimpleCartItemQueryDefinition {
+    void define(SimpleCartItemQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SimpleProductCartItemInput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SimpleProductCartItemInput.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.io.Serializable;
+import java.util.List;
+
+import com.shopify.graphql.support.Input;
+
+public class SimpleProductCartItemInput implements Serializable {
+    private CartItemInput data;
+
+    private Input<List<CustomizableOptionInput>> customizableOptions = Input.undefined();
+
+    public SimpleProductCartItemInput(CartItemInput data) {
+        this.data = data;
+    }
+
+    public CartItemInput getData() {
+        return data;
+    }
+
+    public SimpleProductCartItemInput setData(CartItemInput data) {
+        this.data = data;
+        return this;
+    }
+
+    public List<CustomizableOptionInput> getCustomizableOptions() {
+        return customizableOptions.getValue();
+    }
+
+    public Input<List<CustomizableOptionInput>> getCustomizableOptionsInput() {
+        return customizableOptions;
+    }
+
+    public SimpleProductCartItemInput setCustomizableOptions(List<CustomizableOptionInput> customizableOptions) {
+        this.customizableOptions = Input.optional(customizableOptions);
+        return this;
+    }
+
+    public SimpleProductCartItemInput setCustomizableOptionsInput(Input<List<CustomizableOptionInput>> customizableOptions) {
+        if (customizableOptions == null) {
+            throw new IllegalArgumentException("Input can not be null");
+        }
+        this.customizableOptions = customizableOptions;
+        return this;
+    }
+
+    public void appendTo(StringBuilder _queryBuilder) {
+        String separator = "";
+        _queryBuilder.append('{');
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("data:");
+        data.appendTo(_queryBuilder);
+
+        if (this.customizableOptions.isDefined()) {
+            _queryBuilder.append(separator);
+            separator = ",";
+            _queryBuilder.append("customizable_options:");
+            if (customizableOptions.getValue() != null) {
+                _queryBuilder.append('[');
+                {
+                    String listSeperator1 = "";
+                    for (CustomizableOptionInput item1 : customizableOptions.getValue()) {
+                        _queryBuilder.append(listSeperator1);
+                        listSeperator1 = ",";
+                        item1.appendTo(_queryBuilder);
+                    }
+                }
+                _queryBuilder.append(']');
+            } else {
+                _queryBuilder.append("null");
+            }
+        }
+
+        _queryBuilder.append('}');
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/UnknownCartAddressInterface.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/UnknownCartAddressInterface.java
@@ -1,0 +1,306 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * 
+ */
+public class UnknownCartAddressInterface extends AbstractResponse<UnknownCartAddressInterface> implements CartAddressInterface {
+    public UnknownCartAddressInterface() {
+    }
+
+    public UnknownCartAddressInterface(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "city": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "company": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "country": {
+                    CartAddressCountry optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = new CartAddressCountry(jsonAsObject(field.getValue(), key));
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "customer_notes": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "firstname": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "lastname": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "postcode": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "region": {
+                    CartAddressRegion optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = new CartAddressRegion(jsonAsObject(field.getValue(), key));
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "street": {
+                    List<String> optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        List<String> list1 = new ArrayList<>();
+                        for (JsonElement element1 : jsonAsArray(field.getValue(), key)) {
+                            String optional2 = null;
+                            if (!element1.isJsonNull()) {
+                                optional2 = jsonAsString(element1, key);
+                            }
+
+                            list1.add(optional2);
+                        }
+
+                        optional1 = list1;
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "telephone": {
+                    String optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        optional1 = jsonAsString(field.getValue(), key);
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public static CartAddressInterface create(JsonObject fields) throws SchemaViolationError {
+        String typeName = fields.getAsJsonPrimitive("__typename").getAsString();
+        switch (typeName) {
+            case "BillingCartAddress": {
+                return new BillingCartAddress(fields);
+            }
+
+            case "ShippingCartAddress": {
+                return new ShippingCartAddress(fields);
+            }
+
+            default: {
+                return new UnknownCartAddressInterface(fields);
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return (String) get("__typename");
+    }
+
+    public String getCity() {
+        return (String) get("city");
+    }
+
+    public UnknownCartAddressInterface setCity(String arg) {
+        optimisticData.put(getKey("city"), arg);
+        return this;
+    }
+
+    public String getCompany() {
+        return (String) get("company");
+    }
+
+    public UnknownCartAddressInterface setCompany(String arg) {
+        optimisticData.put(getKey("company"), arg);
+        return this;
+    }
+
+    public CartAddressCountry getCountry() {
+        return (CartAddressCountry) get("country");
+    }
+
+    public UnknownCartAddressInterface setCountry(CartAddressCountry arg) {
+        optimisticData.put(getKey("country"), arg);
+        return this;
+    }
+
+    public String getCustomerNotes() {
+        return (String) get("customer_notes");
+    }
+
+    public UnknownCartAddressInterface setCustomerNotes(String arg) {
+        optimisticData.put(getKey("customer_notes"), arg);
+        return this;
+    }
+
+    public String getFirstname() {
+        return (String) get("firstname");
+    }
+
+    public UnknownCartAddressInterface setFirstname(String arg) {
+        optimisticData.put(getKey("firstname"), arg);
+        return this;
+    }
+
+    public String getLastname() {
+        return (String) get("lastname");
+    }
+
+    public UnknownCartAddressInterface setLastname(String arg) {
+        optimisticData.put(getKey("lastname"), arg);
+        return this;
+    }
+
+    public String getPostcode() {
+        return (String) get("postcode");
+    }
+
+    public UnknownCartAddressInterface setPostcode(String arg) {
+        optimisticData.put(getKey("postcode"), arg);
+        return this;
+    }
+
+    public CartAddressRegion getRegion() {
+        return (CartAddressRegion) get("region");
+    }
+
+    public UnknownCartAddressInterface setRegion(CartAddressRegion arg) {
+        optimisticData.put(getKey("region"), arg);
+        return this;
+    }
+
+    public List<String> getStreet() {
+        return (List<String>) get("street");
+    }
+
+    public UnknownCartAddressInterface setStreet(List<String> arg) {
+        optimisticData.put(getKey("street"), arg);
+        return this;
+    }
+
+    public String getTelephone() {
+        return (String) get("telephone");
+    }
+
+    public UnknownCartAddressInterface setTelephone(String arg) {
+        optimisticData.put(getKey("telephone"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "city": return false;
+
+            case "company": return false;
+
+            case "country": return true;
+
+            case "customer_notes": return false;
+
+            case "firstname": return false;
+
+            case "lastname": return false;
+
+            case "postcode": return false;
+
+            case "region": return true;
+
+            case "street": return false;
+
+            case "telephone": return false;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/UnknownCartItemInterface.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/UnknownCartItemInterface.java
@@ -1,0 +1,129 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * 
+ */
+public class UnknownCartItemInterface extends AbstractResponse<UnknownCartItemInterface> implements CartItemInterface {
+    public UnknownCartItemInterface() {
+    }
+
+    public UnknownCartItemInterface(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "id": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+
+                    break;
+                }
+
+                case "product": {
+                    responseData.put(key, UnknownProductInterface.create(jsonAsObject(field.getValue(), key)));
+
+                    break;
+                }
+
+                case "quantity": {
+                    responseData.put(key, jsonAsDouble(field.getValue(), key));
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public static CartItemInterface create(JsonObject fields) throws SchemaViolationError {
+        String typeName = fields.getAsJsonPrimitive("__typename").getAsString();
+        switch (typeName) {
+            case "ConfigurableCartItem": {
+                return new ConfigurableCartItem(fields);
+            }
+
+            case "SimpleCartItem": {
+                return new SimpleCartItem(fields);
+            }
+
+            case "VirtualCartItem": {
+                return new VirtualCartItem(fields);
+            }
+
+            default: {
+                return new UnknownCartItemInterface(fields);
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return (String) get("__typename");
+    }
+
+    public String getId() {
+        return (String) get("id");
+    }
+
+    public UnknownCartItemInterface setId(String arg) {
+        optimisticData.put(getKey("id"), arg);
+        return this;
+    }
+
+    public ProductInterface getProduct() {
+        return (ProductInterface) get("product");
+    }
+
+    public UnknownCartItemInterface setProduct(ProductInterface arg) {
+        optimisticData.put(getKey("product"), arg);
+        return this;
+    }
+
+    public Double getQuantity() {
+        return (Double) get("quantity");
+    }
+
+    public UnknownCartItemInterface setQuantity(Double arg) {
+        optimisticData.put(getKey("quantity"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "id": return false;
+
+            case "product": return false;
+
+            case "quantity": return false;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/UnknownCustomizableOptionInterface.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/UnknownCustomizableOptionInterface.java
@@ -96,6 +96,10 @@ public class UnknownCustomizableOptionInterface extends AbstractResponse<Unknown
                 return new CustomizableAreaOption(fields);
             }
 
+            case "CustomizableCheckboxOption": {
+                return new CustomizableCheckboxOption(fields);
+            }
+
             case "CustomizableDateOption": {
                 return new CustomizableDateOption(fields);
             }
@@ -110,6 +114,10 @@ public class UnknownCustomizableOptionInterface extends AbstractResponse<Unknown
 
             case "CustomizableFileOption": {
                 return new CustomizableFileOption(fields);
+            }
+
+            case "CustomizableMultipleOption": {
+                return new CustomizableMultipleOption(fields);
             }
 
             case "CustomizableRadioOption": {

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/UpdateCartItemsInput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/UpdateCartItemsInput.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.io.Serializable;
+import java.util.List;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+public class UpdateCartItemsInput implements Serializable {
+    private String cartId;
+
+    private List<CartItemUpdateInput> cartItems;
+
+    public UpdateCartItemsInput(String cartId, List<CartItemUpdateInput> cartItems) {
+        this.cartId = cartId;
+
+        this.cartItems = cartItems;
+    }
+
+    public String getCartId() {
+        return cartId;
+    }
+
+    public UpdateCartItemsInput setCartId(String cartId) {
+        this.cartId = cartId;
+        return this;
+    }
+
+    public List<CartItemUpdateInput> getCartItems() {
+        return cartItems;
+    }
+
+    public UpdateCartItemsInput setCartItems(List<CartItemUpdateInput> cartItems) {
+        this.cartItems = cartItems;
+        return this;
+    }
+
+    public void appendTo(StringBuilder _queryBuilder) {
+        String separator = "";
+        _queryBuilder.append('{');
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("cart_id:");
+        AbstractQuery.appendQuotedString(_queryBuilder, cartId.toString());
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("cart_items:");
+        _queryBuilder.append('[');
+        {
+            String listSeperator1 = "";
+            for (CartItemUpdateInput item1 : cartItems) {
+                _queryBuilder.append(listSeperator1);
+                listSeperator1 = ",";
+                item1.appendTo(_queryBuilder);
+            }
+        }
+        _queryBuilder.append(']');
+
+        _queryBuilder.append('}');
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/UpdateCartItemsOutput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/UpdateCartItemsOutput.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * 
+ */
+public class UpdateCartItemsOutput extends AbstractResponse<UpdateCartItemsOutput> {
+    public UpdateCartItemsOutput() {
+    }
+
+    public UpdateCartItemsOutput(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "cart": {
+                    responseData.put(key, new Cart(jsonAsObject(field.getValue(), key)));
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "UpdateCartItemsOutput";
+    }
+
+    public Cart getCart() {
+        return (Cart) get("cart");
+    }
+
+    public UpdateCartItemsOutput setCart(Cart arg) {
+        optimisticData.put(getKey("cart"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "cart": return true;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/UpdateCartItemsOutputQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/UpdateCartItemsOutputQuery.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * 
+ */
+public class UpdateCartItemsOutputQuery extends AbstractQuery<UpdateCartItemsOutputQuery> {
+    UpdateCartItemsOutputQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    public UpdateCartItemsOutputQuery cart(CartQueryDefinition queryDef) {
+        startField("cart");
+
+        _queryBuilder.append('{');
+        queryDef.define(new CartQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/UpdateCartItemsOutputQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/UpdateCartItemsOutputQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface UpdateCartItemsOutputQueryDefinition {
+    void define(UpdateCartItemsOutputQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/VirtualCartItem.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/VirtualCartItem.java
@@ -1,0 +1,142 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.SchemaViolationError;
+
+/**
+ * Virtual Cart Item
+ */
+public class VirtualCartItem extends AbstractResponse<VirtualCartItem> implements CartItemInterface {
+    public VirtualCartItem() {
+    }
+
+    public VirtualCartItem(JsonObject fields) throws SchemaViolationError {
+        for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+            String key = field.getKey();
+            String fieldName = getFieldName(key);
+            switch (fieldName) {
+                case "customizable_options": {
+                    List<SelectedCustomizableOption> optional1 = null;
+                    if (!field.getValue().isJsonNull()) {
+                        List<SelectedCustomizableOption> list1 = new ArrayList<>();
+                        for (JsonElement element1 : jsonAsArray(field.getValue(), key)) {
+                            SelectedCustomizableOption optional2 = null;
+                            if (!element1.isJsonNull()) {
+                                optional2 = new SelectedCustomizableOption(jsonAsObject(element1, key));
+                            }
+
+                            list1.add(optional2);
+                        }
+
+                        optional1 = list1;
+                    }
+
+                    responseData.put(key, optional1);
+
+                    break;
+                }
+
+                case "id": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+
+                    break;
+                }
+
+                case "product": {
+                    responseData.put(key, UnknownProductInterface.create(jsonAsObject(field.getValue(), key)));
+
+                    break;
+                }
+
+                case "quantity": {
+                    responseData.put(key, jsonAsDouble(field.getValue(), key));
+
+                    break;
+                }
+
+                case "__typename": {
+                    responseData.put(key, jsonAsString(field.getValue(), key));
+                    break;
+                }
+                default: {
+                    throw new SchemaViolationError(this, key, field.getValue());
+                }
+            }
+        }
+    }
+
+    public String getGraphQlTypeName() {
+        return "VirtualCartItem";
+    }
+
+    public List<SelectedCustomizableOption> getCustomizableOptions() {
+        return (List<SelectedCustomizableOption>) get("customizable_options");
+    }
+
+    public VirtualCartItem setCustomizableOptions(List<SelectedCustomizableOption> arg) {
+        optimisticData.put(getKey("customizable_options"), arg);
+        return this;
+    }
+
+    public String getId() {
+        return (String) get("id");
+    }
+
+    public VirtualCartItem setId(String arg) {
+        optimisticData.put(getKey("id"), arg);
+        return this;
+    }
+
+    public ProductInterface getProduct() {
+        return (ProductInterface) get("product");
+    }
+
+    public VirtualCartItem setProduct(ProductInterface arg) {
+        optimisticData.put(getKey("product"), arg);
+        return this;
+    }
+
+    public Double getQuantity() {
+        return (Double) get("quantity");
+    }
+
+    public VirtualCartItem setQuantity(Double arg) {
+        optimisticData.put(getKey("quantity"), arg);
+        return this;
+    }
+
+    public boolean unwrapsToObject(String key) {
+        switch (getFieldName(key)) {
+            case "customizable_options": return true;
+
+            case "id": return false;
+
+            case "product": return false;
+
+            case "quantity": return false;
+
+            default: return false;
+        }
+    }
+}
+

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/VirtualCartItemQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/VirtualCartItemQuery.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import com.shopify.graphql.support.AbstractQuery;
+
+/**
+ * Virtual Cart Item
+ */
+public class VirtualCartItemQuery extends AbstractQuery<VirtualCartItemQuery> {
+    VirtualCartItemQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    public VirtualCartItemQuery customizableOptions(SelectedCustomizableOptionQueryDefinition queryDef) {
+        startField("customizable_options");
+
+        _queryBuilder.append('{');
+        queryDef.define(new SelectedCustomizableOptionQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public VirtualCartItemQuery id() {
+        startField("id");
+
+        return this;
+    }
+
+    public VirtualCartItemQuery product(ProductInterfaceQueryDefinition queryDef) {
+        startField("product");
+
+        _queryBuilder.append('{');
+        queryDef.define(new ProductInterfaceQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
+        return this;
+    }
+
+    public VirtualCartItemQuery quantity() {
+        startField("quantity");
+
+        return this;
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/VirtualCartItemQueryDefinition.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/VirtualCartItemQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+public interface VirtualCartItemQueryDefinition {
+    void define(VirtualCartItemQuery _queryBuilder);
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/VirtualProductCartItemInput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/VirtualProductCartItemInput.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.io.Serializable;
+import java.util.List;
+
+import com.shopify.graphql.support.Input;
+
+public class VirtualProductCartItemInput implements Serializable {
+    private CartItemInput data;
+
+    private Input<List<CustomizableOptionInput>> customizableOptions = Input.undefined();
+
+    public VirtualProductCartItemInput(CartItemInput data) {
+        this.data = data;
+    }
+
+    public CartItemInput getData() {
+        return data;
+    }
+
+    public VirtualProductCartItemInput setData(CartItemInput data) {
+        this.data = data;
+        return this;
+    }
+
+    public List<CustomizableOptionInput> getCustomizableOptions() {
+        return customizableOptions.getValue();
+    }
+
+    public Input<List<CustomizableOptionInput>> getCustomizableOptionsInput() {
+        return customizableOptions;
+    }
+
+    public VirtualProductCartItemInput setCustomizableOptions(List<CustomizableOptionInput> customizableOptions) {
+        this.customizableOptions = Input.optional(customizableOptions);
+        return this;
+    }
+
+    public VirtualProductCartItemInput setCustomizableOptionsInput(Input<List<CustomizableOptionInput>> customizableOptions) {
+        if (customizableOptions == null) {
+            throw new IllegalArgumentException("Input can not be null");
+        }
+        this.customizableOptions = customizableOptions;
+        return this;
+    }
+
+    public void appendTo(StringBuilder _queryBuilder) {
+        String separator = "";
+        _queryBuilder.append('{');
+
+        _queryBuilder.append(separator);
+        separator = ",";
+        _queryBuilder.append("data:");
+        data.appendTo(_queryBuilder);
+
+        if (this.customizableOptions.isDefined()) {
+            _queryBuilder.append(separator);
+            separator = ",";
+            _queryBuilder.append("customizable_options:");
+            if (customizableOptions.getValue() != null) {
+                _queryBuilder.append('[');
+                {
+                    String listSeperator1 = "";
+                    for (CustomizableOptionInput item1 : customizableOptions.getValue()) {
+                        _queryBuilder.append(listSeperator1);
+                        listSeperator1 = ",";
+                        item1.appendTo(_queryBuilder);
+                    }
+                }
+                _queryBuilder.append(']');
+            } else {
+                _queryBuilder.append("null");
+            }
+        }
+
+        _queryBuilder.append('}');
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/createEmptyCartInput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/createEmptyCartInput.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.adobe.cq.commerce.magento.graphql;
+
+import java.io.Serializable;
+
+import com.shopify.graphql.support.AbstractQuery;
+import com.shopify.graphql.support.Input;
+
+public class createEmptyCartInput implements Serializable {
+    private Input<String> cartId = Input.undefined();
+
+    public String getCartId() {
+        return cartId.getValue();
+    }
+
+    public Input<String> getCartIdInput() {
+        return cartId;
+    }
+
+    public createEmptyCartInput setCartId(String cartId) {
+        this.cartId = Input.optional(cartId);
+        return this;
+    }
+
+    public createEmptyCartInput setCartIdInput(Input<String> cartId) {
+        if (cartId == null) {
+            throw new IllegalArgumentException("Input can not be null");
+        }
+        this.cartId = cartId;
+        return this;
+    }
+
+    public void appendTo(StringBuilder _queryBuilder) {
+        String separator = "";
+        _queryBuilder.append('{');
+
+        if (this.cartId.isDefined()) {
+            _queryBuilder.append(separator);
+            separator = ",";
+            _queryBuilder.append("cart_id:");
+            if (cartId.getValue() != null) {
+                AbstractQuery.appendQuotedString(_queryBuilder, cartId.getValue().toString());
+            } else {
+                _queryBuilder.append("null");
+            }
+        }
+
+        _queryBuilder.append('}');
+    }
+}

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/package-info.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/package-info.java
@@ -12,7 +12,7 @@
  *
  ******************************************************************************/
 
-@Version("2.0.0")
+@Version("3.0.0")
 package com.adobe.cq.commerce.magento.graphql;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
- regenerated the classes with Magento 2.3.2

I upgraded the bundle and OSGi package version to `3.0.0` although `2.1.0` would be enough, in order to "OSGi enforce" that this is a "major" GraphQL release (although also not identified as such in the Magento versioning scheme). Not sure what is preferred.