### PR TITLE
CIF-1004 - Allow string values for Magento GraphQL primitives

### DIFF
--- a/src/main/java/com/shopify/graphql/support/AbstractResponse.java
+++ b/src/main/java/com/shopify/graphql/support/AbstractResponse.java
@@ -86,7 +86,7 @@ public abstract class AbstractResponse<T extends AbstractResponse> implements Se
     }
 
     protected Integer jsonAsInteger(JsonElement element, String field) throws SchemaViolationError {
-        if (!element.isJsonPrimitive() || !element.getAsJsonPrimitive().isNumber()) {
+        if (!element.isJsonPrimitive() || (!element.getAsJsonPrimitive().isNumber() && !element.getAsJsonPrimitive().isString())) {
             throw new SchemaViolationError(this, field, element);
         }
         try {
@@ -97,14 +97,18 @@ public abstract class AbstractResponse<T extends AbstractResponse> implements Se
     }
 
     protected Double jsonAsDouble(JsonElement element, String field) throws SchemaViolationError {
-        if (!element.isJsonPrimitive() || !element.getAsJsonPrimitive().isNumber()) {
+        if (!element.isJsonPrimitive() || (!element.getAsJsonPrimitive().isNumber() && !element.getAsJsonPrimitive().isString())) {
             throw new SchemaViolationError(this, field, element);
         }
-        return element.getAsJsonPrimitive().getAsDouble();
+        try {
+            return element.getAsJsonPrimitive().getAsDouble();
+        } catch (NumberFormatException exc) {
+            throw new SchemaViolationError(this, field, element);
+        }
     }
 
     protected Boolean jsonAsBoolean(JsonElement element, String field) throws SchemaViolationError {
-        if (!element.isJsonPrimitive() || !element.getAsJsonPrimitive().isBoolean()) {
+        if (!element.isJsonPrimitive() || (!element.getAsJsonPrimitive().isBoolean() && !element.getAsJsonPrimitive().isString())) {
             throw new SchemaViolationError(this, field, element);
         }
         return element.getAsJsonPrimitive().getAsBoolean();

--- a/src/test/java/com/adobe/cq/commerce/magento/graphql/QueryBuilderTest.java
+++ b/src/test/java/com/adobe/cq/commerce/magento/graphql/QueryBuilderTest.java
@@ -57,7 +57,13 @@ public class QueryBuilderTest {
         Assert.assertEquals("Test Simple Product", product.getName());
         Assert.assertEquals("test-category", product.getCategories().get(0).getUrlPath());
         Assert.assertEquals(CurrencyEnum.USD, product.getPrice().getRegularPrice().getAmount().getCurrency());
-        Assert.assertEquals(22, product.getPrice().getRegularPrice().getAmount().getValue(), 0);
+        Assert.assertEquals(22.2, product.getPrice().getRegularPrice().getAmount().getValue(), 0);
+
+        // Test that primitives returned a strings get converted to primitive types
+        Assert.assertEquals(Integer.valueOf(1), product.getColor());
+        Assert.assertEquals(1.2, product.getSpecialPrice(), 0);
+        Assert.assertEquals(Boolean.TRUE, product.getMediaGalleryEntries().get(0).getDisabled());
+        Assert.assertEquals(Boolean.TRUE, product.getMediaGalleryEntries().get(1).getDisabled());
     }
 
     @Test

--- a/src/test/resources/responses/product-by-sku.json
+++ b/src/test/resources/responses/product-by-sku.json
@@ -9,12 +9,22 @@
         "description": {
           "html": ""
         },
+        "color": "1",
+        "special_price": "1.2",
         "image": {
           "url": "https://hostname/images/product/placeholder/image.jpg"
         },
         "thumbnail": {
           "url": "https://hostname/images/product/placeholder/image.jpg"
         },
+        "media_gallery_entries": [
+          {
+            "disabled": true
+          },
+          {
+            "disabled": "true"
+          }
+        ],
         "url_key": "test-simple-product",
         "updated_at": "2019-03-29 08:20:40",
         "created_at": "2019-03-29 08:20:40",
@@ -22,7 +32,7 @@
           "regularPrice": {
             "amount": {
               "currency": "USD",
-              "value": 22
+              "value": 22.2
             }
           }
         },


### PR DESCRIPTION
## Motivation and Context

The code currently throws an exception when, for example, an Integer primitive is defined as a String in the Magento JSON response. This is an issue, because somehow some Magento instances with certain configuration do for example return strings for the "color" attribute, while this is defined as an integer in the schema.

To fix this, we should loosen the generated code so that it accepts string values for primitives like integer, double, and boolean.

## How Has This Been Tested?

Extended unit tests.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
