### PR TITLE
CIF-1052 - Allow custom fields in the Magento GraphQL library

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 
 This project contains the Magento GraphQL data models and query builders that have been automatically generated based on the default/generic (= out-of-the-box) Magento GraphQL schema. These classes can be used to build GraphQL requests and to parse/deserialise GraphQL JSON responses into java objects. These files are suitable for all projects that want to manipulate the default set of objects and attributes available in Magento, without any need to access for example customized product attributes.
 
-If you want to access customized attributes like extra product attributes added to your product attributes set in Magento, you can use the [GraphQL Java Generator](https://github.com/adobe/graphql-java-generator) to generate a similar set of java classes that would include the custom attributes of your Magento project. 
+If you want to access customized attributes like extra product attributes added to your product attributes set in Magento, you can use the [GraphQL Java Generator](https://github.com/adobe/graphql-java-generator) to generate a similar set of Java classes that would include the custom attributes of your Magento project. 
 
+Starting with version `3.1.0-magento232`, this library now also supports custom query fields. That is, it is now possible to add custom fields to any GraphQL query without having to regenerate the Java classes, and the deserialization of JSON responses will accept and allow the parsing of custom fields. See the examples in the [unit tests](src/test/java/com/adobe/cq/commerce/magento/graphql/) to find out more about that new feature. Note that this feature should be used with care because it basically bypasses the type-checking enforced by the query builders and the deserialization.
 
 ## Installation
 

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/AddConfigurableProductsToCartOutput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/AddConfigurableProductsToCartOutput.java
@@ -43,8 +43,9 @@ public class AddConfigurableProductsToCartOutput extends AbstractResponse<AddCon
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/AddSimpleProductsToCartOutput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/AddSimpleProductsToCartOutput.java
@@ -43,8 +43,9 @@ public class AddSimpleProductsToCartOutput extends AbstractResponse<AddSimplePro
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/AddVirtualProductsToCartOutput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/AddVirtualProductsToCartOutput.java
@@ -43,8 +43,9 @@ public class AddVirtualProductsToCartOutput extends AbstractResponse<AddVirtualP
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/AppliedCoupon.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/AppliedCoupon.java
@@ -43,8 +43,9 @@ public class AppliedCoupon extends AbstractResponse<AppliedCoupon> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/ApplyCouponToCartOutput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/ApplyCouponToCartOutput.java
@@ -43,8 +43,9 @@ public class ApplyCouponToCartOutput extends AbstractResponse<ApplyCouponToCartO
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/Attribute.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/Attribute.java
@@ -93,8 +93,9 @@ public class Attribute extends AbstractResponse<Attribute> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/AttributeOption.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/AttributeOption.java
@@ -59,8 +59,9 @@ public class AttributeOption extends AbstractResponse<AttributeOption> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/AvailablePaymentMethod.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/AvailablePaymentMethod.java
@@ -49,8 +49,9 @@ public class AvailablePaymentMethod extends AbstractResponse<AvailablePaymentMet
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/AvailableShippingMethod.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/AvailableShippingMethod.java
@@ -117,8 +117,9 @@ public class AvailableShippingMethod extends AbstractResponse<AvailableShippingM
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/BillingCartAddress.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/BillingCartAddress.java
@@ -159,8 +159,9 @@ public class BillingCartAddress extends AbstractResponse<BillingCartAddress> imp
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/Breadcrumb.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/Breadcrumb.java
@@ -81,8 +81,9 @@ public class Breadcrumb extends AbstractResponse<Breadcrumb> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/BundleItem.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/BundleItem.java
@@ -126,8 +126,9 @@ public class BundleItem extends AbstractResponse<BundleItem> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/BundleItemOption.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/BundleItemOption.java
@@ -136,8 +136,9 @@ public class BundleItemOption extends AbstractResponse<BundleItemOption> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/BundleProduct.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/BundleProduct.java
@@ -636,8 +636,9 @@ public class BundleProduct extends AbstractResponse<BundleProduct> implements Cu
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/Cart.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/Cart.java
@@ -147,8 +147,9 @@ public class Cart extends AbstractResponse<Cart> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CartAddressCountry.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CartAddressCountry.java
@@ -59,8 +59,9 @@ public class CartAddressCountry extends AbstractResponse<CartAddressCountry> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CartAddressInterface.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CartAddressInterface.java
@@ -16,11 +16,13 @@ package com.adobe.cq.commerce.magento.graphql;
 
 import java.util.List;
 
+import com.shopify.graphql.support.CustomFieldInterface;
+
 /**
  * 
  */
 
-public interface CartAddressInterface {
+public interface CartAddressInterface extends CustomFieldInterface {
     String getGraphQlTypeName();
 
     String getCity();

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CartAddressRegion.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CartAddressRegion.java
@@ -59,8 +59,9 @@ public class CartAddressRegion extends AbstractResponse<CartAddressRegion> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CartItemInterface.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CartItemInterface.java
@@ -14,11 +14,13 @@
 
 package com.adobe.cq.commerce.magento.graphql;
 
+import com.shopify.graphql.support.CustomFieldInterface;
+
 /**
  * 
  */
 
-public interface CartItemInterface {
+public interface CartItemInterface extends CustomFieldInterface {
     String getGraphQlTypeName();
 
     String getId();

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CartItemQuantity.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CartItemQuantity.java
@@ -49,8 +49,9 @@ public class CartItemQuantity extends AbstractResponse<CartItemQuantity> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CartItemSelectedOptionValuePrice.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CartItemSelectedOptionValuePrice.java
@@ -55,8 +55,9 @@ public class CartItemSelectedOptionValuePrice extends AbstractResponse<CartItemS
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CartPrices.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CartPrices.java
@@ -104,8 +104,9 @@ public class CartPrices extends AbstractResponse<CartPrices> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CartTaxItem.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CartTaxItem.java
@@ -49,8 +49,9 @@ public class CartTaxItem extends AbstractResponse<CartTaxItem> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CategoryInterface.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CategoryInterface.java
@@ -16,11 +16,13 @@ package com.adobe.cq.commerce.magento.graphql;
 
 import java.util.List;
 
+import com.shopify.graphql.support.CustomFieldInterface;
+
 /**
  * CategoryInterface contains the full set of attributes that can be returned in a category search
  */
 
-public interface CategoryInterface {
+public interface CategoryInterface extends CustomFieldInterface {
     String getGraphQlTypeName();
 
     List<String> getAvailableSortBy();

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CategoryProducts.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CategoryProducts.java
@@ -82,8 +82,9 @@ public class CategoryProducts extends AbstractResponse<CategoryProducts> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CategoryTree.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CategoryTree.java
@@ -366,8 +366,9 @@ public class CategoryTree extends AbstractResponse<CategoryTree> implements Cate
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CmsBlock.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CmsBlock.java
@@ -70,8 +70,9 @@ public class CmsBlock extends AbstractResponse<CmsBlock> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CmsBlocks.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CmsBlocks.java
@@ -60,8 +60,9 @@ public class CmsBlocks extends AbstractResponse<CmsBlocks> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CmsPage.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CmsPage.java
@@ -125,8 +125,9 @@ public class CmsPage extends AbstractResponse<CmsPage> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/ComplexTextValue.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/ComplexTextValue.java
@@ -43,8 +43,9 @@ public class ComplexTextValue extends AbstractResponse<ComplexTextValue> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/ConfigurableAttributeOption.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/ConfigurableAttributeOption.java
@@ -71,8 +71,9 @@ public class ConfigurableAttributeOption extends AbstractResponse<ConfigurableAt
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/ConfigurableCartItem.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/ConfigurableCartItem.java
@@ -89,8 +89,9 @@ public class ConfigurableCartItem extends AbstractResponse<ConfigurableCartItem>
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/ConfigurableProduct.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/ConfigurableProduct.java
@@ -602,8 +602,9 @@ public class ConfigurableProduct extends AbstractResponse<ConfigurableProduct> i
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/ConfigurableProductOptions.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/ConfigurableProductOptions.java
@@ -137,8 +137,9 @@ public class ConfigurableProductOptions extends AbstractResponse<ConfigurablePro
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/ConfigurableProductOptionsValues.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/ConfigurableProductOptionsValues.java
@@ -92,8 +92,9 @@ public class ConfigurableProductOptionsValues extends AbstractResponse<Configura
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/ConfigurableVariant.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/ConfigurableVariant.java
@@ -71,8 +71,9 @@ public class ConfigurableVariant extends AbstractResponse<ConfigurableVariant> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/Country.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/Country.java
@@ -115,8 +115,9 @@ public class Country extends AbstractResponse<Country> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/Currency.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/Currency.java
@@ -147,8 +147,9 @@ public class Currency extends AbstractResponse<Currency> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomAttributeMetadata.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomAttributeMetadata.java
@@ -60,8 +60,9 @@ public class CustomAttributeMetadata extends AbstractResponse<CustomAttributeMet
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/Customer.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/Customer.java
@@ -225,8 +225,9 @@ public class Customer extends AbstractResponse<Customer> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomerAddress.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomerAddress.java
@@ -300,8 +300,9 @@ public class CustomerAddress extends AbstractResponse<CustomerAddress> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomerAddressAttribute.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomerAddressAttribute.java
@@ -59,8 +59,9 @@ public class CustomerAddressAttribute extends AbstractResponse<CustomerAddressAt
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomerAddressRegion.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomerAddressRegion.java
@@ -70,8 +70,9 @@ public class CustomerAddressRegion extends AbstractResponse<CustomerAddressRegio
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomerDownloadableProduct.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomerDownloadableProduct.java
@@ -92,8 +92,9 @@ public class CustomerDownloadableProduct extends AbstractResponse<CustomerDownlo
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomerDownloadableProducts.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomerDownloadableProducts.java
@@ -60,8 +60,9 @@ public class CustomerDownloadableProducts extends AbstractResponse<CustomerDownl
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomerOrder.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomerOrder.java
@@ -92,8 +92,9 @@ public class CustomerOrder extends AbstractResponse<CustomerOrder> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomerOrders.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomerOrders.java
@@ -60,8 +60,9 @@ public class CustomerOrders extends AbstractResponse<CustomerOrders> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomerOutput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomerOutput.java
@@ -43,8 +43,9 @@ public class CustomerOutput extends AbstractResponse<CustomerOutput> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomerPaymentTokens.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomerPaymentTokens.java
@@ -55,8 +55,9 @@ public class CustomerPaymentTokens extends AbstractResponse<CustomerPaymentToken
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomerToken.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomerToken.java
@@ -48,8 +48,9 @@ public class CustomerToken extends AbstractResponse<CustomerToken> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableAreaOption.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableAreaOption.java
@@ -104,8 +104,9 @@ public class CustomizableAreaOption extends AbstractResponse<CustomizableAreaOpt
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableAreaValue.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableAreaValue.java
@@ -82,8 +82,9 @@ public class CustomizableAreaValue extends AbstractResponse<CustomizableAreaValu
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableCheckboxOption.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableCheckboxOption.java
@@ -105,8 +105,9 @@ public class CustomizableCheckboxOption extends AbstractResponse<CustomizableChe
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableCheckboxValue.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableCheckboxValue.java
@@ -104,8 +104,9 @@ public class CustomizableCheckboxValue extends AbstractResponse<CustomizableChec
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableDateOption.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableDateOption.java
@@ -104,8 +104,9 @@ public class CustomizableDateOption extends AbstractResponse<CustomizableDateOpt
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableDateValue.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableDateValue.java
@@ -71,8 +71,9 @@ public class CustomizableDateValue extends AbstractResponse<CustomizableDateValu
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableDropDownOption.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableDropDownOption.java
@@ -105,8 +105,9 @@ public class CustomizableDropDownOption extends AbstractResponse<CustomizableDro
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableDropDownValue.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableDropDownValue.java
@@ -104,8 +104,9 @@ public class CustomizableDropDownValue extends AbstractResponse<CustomizableDrop
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableFieldOption.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableFieldOption.java
@@ -104,8 +104,9 @@ public class CustomizableFieldOption extends AbstractResponse<CustomizableFieldO
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableFieldValue.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableFieldValue.java
@@ -82,8 +82,9 @@ public class CustomizableFieldValue extends AbstractResponse<CustomizableFieldVa
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableFileOption.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableFileOption.java
@@ -104,8 +104,9 @@ public class CustomizableFileOption extends AbstractResponse<CustomizableFileOpt
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableFileValue.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableFileValue.java
@@ -104,8 +104,9 @@ public class CustomizableFileValue extends AbstractResponse<CustomizableFileValu
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableMultipleOption.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableMultipleOption.java
@@ -105,8 +105,9 @@ public class CustomizableMultipleOption extends AbstractResponse<CustomizableMul
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableMultipleValue.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableMultipleValue.java
@@ -104,8 +104,9 @@ public class CustomizableMultipleValue extends AbstractResponse<CustomizableMult
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableOptionInterface.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableOptionInterface.java
@@ -14,12 +14,14 @@
 
 package com.adobe.cq.commerce.magento.graphql;
 
+import com.shopify.graphql.support.CustomFieldInterface;
+
 /**
  * The CustomizableOptionInterface contains basic information about a customizable option. It can be
  * implemented by several types of configurable options.
  */
 
-public interface CustomizableOptionInterface {
+public interface CustomizableOptionInterface extends CustomFieldInterface {
     String getGraphQlTypeName();
 
     Integer getOptionId();

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableProductInterface.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableProductInterface.java
@@ -16,11 +16,13 @@ package com.adobe.cq.commerce.magento.graphql;
 
 import java.util.List;
 
+import com.shopify.graphql.support.CustomFieldInterface;
+
 /**
  * CustomizableProductInterface contains information about customizable product options.
  */
 
-public interface CustomizableProductInterface {
+public interface CustomizableProductInterface extends CustomFieldInterface {
     String getGraphQlTypeName();
 
     List<CustomizableOptionInterface> getOptions();

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableRadioOption.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableRadioOption.java
@@ -105,8 +105,9 @@ public class CustomizableRadioOption extends AbstractResponse<CustomizableRadioO
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableRadioValue.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableRadioValue.java
@@ -104,8 +104,9 @@ public class CustomizableRadioValue extends AbstractResponse<CustomizableRadioVa
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/DeletePaymentTokenOutput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/DeletePaymentTokenOutput.java
@@ -54,8 +54,9 @@ public class DeletePaymentTokenOutput extends AbstractResponse<DeletePaymentToke
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/DownloadableProduct.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/DownloadableProduct.java
@@ -613,8 +613,9 @@ public class DownloadableProduct extends AbstractResponse<DownloadableProduct> i
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/DownloadableProductLinks.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/DownloadableProductLinks.java
@@ -147,8 +147,9 @@ public class DownloadableProductLinks extends AbstractResponse<DownloadableProdu
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/DownloadableProductSamples.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/DownloadableProductSamples.java
@@ -103,8 +103,9 @@ public class DownloadableProductSamples extends AbstractResponse<DownloadablePro
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/EntityUrl.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/EntityUrl.java
@@ -81,8 +81,9 @@ public class EntityUrl extends AbstractResponse<EntityUrl> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/ExchangeRate.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/ExchangeRate.java
@@ -59,8 +59,9 @@ public class ExchangeRate extends AbstractResponse<ExchangeRate> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/GroupedProduct.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/GroupedProduct.java
@@ -560,8 +560,9 @@ public class GroupedProduct extends AbstractResponse<GroupedProduct> implements 
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/GroupedProductItem.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/GroupedProductItem.java
@@ -70,8 +70,9 @@ public class GroupedProductItem extends AbstractResponse<GroupedProductItem> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/HttpQueryParameter.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/HttpQueryParameter.java
@@ -59,8 +59,9 @@ public class HttpQueryParameter extends AbstractResponse<HttpQueryParameter> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/IsEmailAvailableOutput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/IsEmailAvailableOutput.java
@@ -48,8 +48,9 @@ public class IsEmailAvailableOutput extends AbstractResponse<IsEmailAvailableOut
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/LayerFilter.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/LayerFilter.java
@@ -93,8 +93,9 @@ public class LayerFilter extends AbstractResponse<LayerFilter> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/LayerFilterItem.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/LayerFilterItem.java
@@ -70,8 +70,9 @@ public class LayerFilterItem extends AbstractResponse<LayerFilterItem> implement
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/LayerFilterItemInterface.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/LayerFilterItemInterface.java
@@ -14,11 +14,13 @@
 
 package com.adobe.cq.commerce.magento.graphql;
 
+import com.shopify.graphql.support.CustomFieldInterface;
+
 /**
  * 
  */
 
-public interface LayerFilterItemInterface {
+public interface LayerFilterItemInterface extends CustomFieldInterface {
     String getGraphQlTypeName();
 
     Integer getItemsCount();

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/MediaGalleryEntry.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/MediaGalleryEntry.java
@@ -148,8 +148,9 @@ public class MediaGalleryEntry extends AbstractResponse<MediaGalleryEntry> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/Money.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/Money.java
@@ -59,8 +59,9 @@ public class Money extends AbstractResponse<Money> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/Mutation.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/Mutation.java
@@ -301,8 +301,9 @@ public class Mutation extends AbstractResponse<Mutation> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/Order.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/Order.java
@@ -48,8 +48,9 @@ public class Order extends AbstractResponse<Order> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/PaymentToken.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/PaymentToken.java
@@ -66,8 +66,9 @@ public class PaymentToken extends AbstractResponse<PaymentToken> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/PhysicalProductInterface.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/PhysicalProductInterface.java
@@ -14,11 +14,13 @@
 
 package com.adobe.cq.commerce.magento.graphql;
 
+import com.shopify.graphql.support.CustomFieldInterface;
+
 /**
  * PhysicalProductInterface contains attributes specific to tangible products
  */
 
-public interface PhysicalProductInterface {
+public interface PhysicalProductInterface extends CustomFieldInterface {
     String getGraphQlTypeName();
 
     Double getWeight();

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/PlaceOrderOutput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/PlaceOrderOutput.java
@@ -43,8 +43,9 @@ public class PlaceOrderOutput extends AbstractResponse<PlaceOrderOutput> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/Price.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/Price.java
@@ -71,8 +71,9 @@ public class Price extends AbstractResponse<Price> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/PriceAdjustment.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/PriceAdjustment.java
@@ -71,8 +71,9 @@ public class PriceAdjustment extends AbstractResponse<PriceAdjustment> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/ProductImage.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/ProductImage.java
@@ -59,8 +59,9 @@ public class ProductImage extends AbstractResponse<ProductImage> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/ProductInterface.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/ProductInterface.java
@@ -16,12 +16,14 @@ package com.adobe.cq.commerce.magento.graphql;
 
 import java.util.List;
 
+import com.shopify.graphql.support.CustomFieldInterface;
+
 /**
  * The ProductInterface contains attributes that are common to all types of products. Note that
  * descriptions may not be available for custom and EAV attributes.
  */
 
-public interface ProductInterface {
+public interface ProductInterface extends CustomFieldInterface {
     String getGraphQlTypeName();
 
     Integer getAttributeSetId();

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/ProductLinks.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/ProductLinks.java
@@ -92,8 +92,9 @@ public class ProductLinks extends AbstractResponse<ProductLinks> implements Prod
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/ProductLinksInterface.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/ProductLinksInterface.java
@@ -14,12 +14,14 @@
 
 package com.adobe.cq.commerce.magento.graphql;
 
+import com.shopify.graphql.support.CustomFieldInterface;
+
 /**
  * ProductLinks contains information about linked products, including the link type and product type of
  * each item.
  */
 
-public interface ProductLinksInterface {
+public interface ProductLinksInterface extends CustomFieldInterface {
     String getGraphQlTypeName();
 
     String getLinkType();

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/ProductMediaGalleryEntriesContent.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/ProductMediaGalleryEntriesContent.java
@@ -71,8 +71,9 @@ public class ProductMediaGalleryEntriesContent extends AbstractResponse<ProductM
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/ProductMediaGalleryEntriesVideoContent.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/ProductMediaGalleryEntriesVideoContent.java
@@ -104,8 +104,9 @@ public class ProductMediaGalleryEntriesVideoContent extends AbstractResponse<Pro
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/ProductPrices.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/ProductPrices.java
@@ -72,8 +72,9 @@ public class ProductPrices extends AbstractResponse<ProductPrices> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/ProductTierPrices.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/ProductTierPrices.java
@@ -93,8 +93,9 @@ public class ProductTierPrices extends AbstractResponse<ProductTierPrices> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/Products.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/Products.java
@@ -114,8 +114,9 @@ public class Products extends AbstractResponse<Products> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/Query.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/Query.java
@@ -236,8 +236,9 @@ public class Query extends AbstractResponse<Query> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/Region.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/Region.java
@@ -70,8 +70,9 @@ public class Region extends AbstractResponse<Region> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/RemoveCouponFromCartOutput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/RemoveCouponFromCartOutput.java
@@ -48,8 +48,9 @@ public class RemoveCouponFromCartOutput extends AbstractResponse<RemoveCouponFro
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/RemoveItemFromCartOutput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/RemoveItemFromCartOutput.java
@@ -43,8 +43,9 @@ public class RemoveItemFromCartOutput extends AbstractResponse<RemoveItemFromCar
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/RevokeCustomerTokenOutput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/RevokeCustomerTokenOutput.java
@@ -43,8 +43,9 @@ public class RevokeCustomerTokenOutput extends AbstractResponse<RevokeCustomerTo
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SearchResultPageInfo.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SearchResultPageInfo.java
@@ -70,8 +70,9 @@ public class SearchResultPageInfo extends AbstractResponse<SearchResultPageInfo>
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedConfigurableOption.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedConfigurableOption.java
@@ -61,8 +61,9 @@ public class SelectedConfigurableOption extends AbstractResponse<SelectedConfigu
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedCustomizableOption.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedCustomizableOption.java
@@ -79,8 +79,9 @@ public class SelectedCustomizableOption extends AbstractResponse<SelectedCustomi
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedCustomizableOptionValue.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedCustomizableOptionValue.java
@@ -66,8 +66,9 @@ public class SelectedCustomizableOptionValue extends AbstractResponse<SelectedCu
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedPaymentMethod.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedPaymentMethod.java
@@ -60,8 +60,9 @@ public class SelectedPaymentMethod extends AbstractResponse<SelectedPaymentMetho
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedShippingMethod.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SelectedShippingMethod.java
@@ -103,8 +103,9 @@ public class SelectedShippingMethod extends AbstractResponse<SelectedShippingMet
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SendEmailToFriendOutput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SendEmailToFriendOutput.java
@@ -71,8 +71,9 @@ public class SendEmailToFriendOutput extends AbstractResponse<SendEmailToFriendO
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SendEmailToFriendRecipient.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SendEmailToFriendRecipient.java
@@ -49,8 +49,9 @@ public class SendEmailToFriendRecipient extends AbstractResponse<SendEmailToFrie
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SendEmailToFriendSender.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SendEmailToFriendSender.java
@@ -55,8 +55,9 @@ public class SendEmailToFriendSender extends AbstractResponse<SendEmailToFriendS
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SetBillingAddressOnCartOutput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SetBillingAddressOnCartOutput.java
@@ -43,8 +43,9 @@ public class SetBillingAddressOnCartOutput extends AbstractResponse<SetBillingAd
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SetGuestEmailOnCartOutput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SetGuestEmailOnCartOutput.java
@@ -43,8 +43,9 @@ public class SetGuestEmailOnCartOutput extends AbstractResponse<SetGuestEmailOnC
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SetPaymentMethodOnCartOutput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SetPaymentMethodOnCartOutput.java
@@ -43,8 +43,9 @@ public class SetPaymentMethodOnCartOutput extends AbstractResponse<SetPaymentMet
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SetShippingAddressesOnCartOutput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SetShippingAddressesOnCartOutput.java
@@ -43,8 +43,9 @@ public class SetShippingAddressesOnCartOutput extends AbstractResponse<SetShippi
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SetShippingMethodsOnCartOutput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SetShippingMethodsOnCartOutput.java
@@ -43,8 +43,9 @@ public class SetShippingMethodsOnCartOutput extends AbstractResponse<SetShipping
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/ShippingCartAddress.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/ShippingCartAddress.java
@@ -223,8 +223,9 @@ public class ShippingCartAddress extends AbstractResponse<ShippingCartAddress> i
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SimpleCartItem.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SimpleCartItem.java
@@ -78,8 +78,9 @@ public class SimpleCartItem extends AbstractResponse<SimpleCartItem> implements 
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SimpleProduct.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SimpleProduct.java
@@ -560,8 +560,9 @@ public class SimpleProduct extends AbstractResponse<SimpleProduct> implements Cu
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SortField.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SortField.java
@@ -59,8 +59,9 @@ public class SortField extends AbstractResponse<SortField> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SortFields.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SortFields.java
@@ -71,8 +71,9 @@ public class SortFields extends AbstractResponse<SortFields> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/StoreConfig.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/StoreConfig.java
@@ -444,8 +444,9 @@ public class StoreConfig extends AbstractResponse<StoreConfig> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SwatchData.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SwatchData.java
@@ -59,8 +59,9 @@ public class SwatchData extends AbstractResponse<SwatchData> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SwatchLayerFilterItem.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SwatchLayerFilterItem.java
@@ -81,8 +81,9 @@ public class SwatchLayerFilterItem extends AbstractResponse<SwatchLayerFilterIte
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SwatchLayerFilterItemInterface.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SwatchLayerFilterItemInterface.java
@@ -14,11 +14,13 @@
 
 package com.adobe.cq.commerce.magento.graphql;
 
+import com.shopify.graphql.support.CustomFieldInterface;
+
 /**
  * 
  */
 
-public interface SwatchLayerFilterItemInterface {
+public interface SwatchLayerFilterItemInterface extends CustomFieldInterface {
     String getGraphQlTypeName();
 
     SwatchData getSwatchData();

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/UnknownCartAddressInterface.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/UnknownCartAddressInterface.java
@@ -159,8 +159,9 @@ public class UnknownCartAddressInterface extends AbstractResponse<UnknownCartAdd
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/UnknownCartItemInterface.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/UnknownCartItemInterface.java
@@ -55,8 +55,9 @@ public class UnknownCartItemInterface extends AbstractResponse<UnknownCartItemIn
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/UnknownCategoryInterface.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/UnknownCategoryInterface.java
@@ -345,8 +345,9 @@ public class UnknownCategoryInterface extends AbstractResponse<UnknownCategoryIn
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/UnknownCustomizableOptionInterface.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/UnknownCustomizableOptionInterface.java
@@ -82,8 +82,9 @@ public class UnknownCustomizableOptionInterface extends AbstractResponse<Unknown
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/UnknownCustomizableProductInterface.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/UnknownCustomizableProductInterface.java
@@ -60,8 +60,9 @@ public class UnknownCustomizableProductInterface extends AbstractResponse<Unknow
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/UnknownLayerFilterItemInterface.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/UnknownLayerFilterItemInterface.java
@@ -70,8 +70,9 @@ public class UnknownLayerFilterItemInterface extends AbstractResponse<UnknownLay
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/UnknownPhysicalProductInterface.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/UnknownPhysicalProductInterface.java
@@ -48,8 +48,9 @@ public class UnknownPhysicalProductInterface extends AbstractResponse<UnknownPhy
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/UnknownProductInterface.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/UnknownProductInterface.java
@@ -529,8 +529,9 @@ public class UnknownProductInterface extends AbstractResponse<UnknownProductInte
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/UnknownProductLinksInterface.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/UnknownProductLinksInterface.java
@@ -93,8 +93,9 @@ public class UnknownProductLinksInterface extends AbstractResponse<UnknownProduc
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/UnknownSwatchLayerFilterItemInterface.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/UnknownSwatchLayerFilterItemInterface.java
@@ -48,8 +48,9 @@ public class UnknownSwatchLayerFilterItemInterface extends AbstractResponse<Unkn
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/UpdateCartItemsOutput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/UpdateCartItemsOutput.java
@@ -43,8 +43,9 @@ public class UpdateCartItemsOutput extends AbstractResponse<UpdateCartItemsOutpu
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/UrlRewrite.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/UrlRewrite.java
@@ -71,8 +71,9 @@ public class UrlRewrite extends AbstractResponse<UrlRewrite> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/VirtualCartItem.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/VirtualCartItem.java
@@ -78,8 +78,9 @@ public class VirtualCartItem extends AbstractResponse<VirtualCartItem> implement
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/VirtualProduct.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/VirtualProduct.java
@@ -550,8 +550,9 @@ public class VirtualProduct extends AbstractResponse<VirtualProduct> implements 
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/Website.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/Website.java
@@ -103,8 +103,9 @@ public class Website extends AbstractResponse<Website> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/WishlistItem.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/WishlistItem.java
@@ -92,8 +92,9 @@ public class WishlistItem extends AbstractResponse<WishlistItem> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/WishlistOutput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/WishlistOutput.java
@@ -104,8 +104,9 @@ public class WishlistOutput extends AbstractResponse<WishlistOutput> {
                     responseData.put(key, jsonAsString(field.getValue(), key));
                     break;
                 }
+
                 default: {
-                    throw new SchemaViolationError(this, key, field.getValue());
+                    readCustomField(fieldName, field.getValue());
                 }
             }
         }

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/package-info.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/package-info.java
@@ -12,7 +12,7 @@
  *
  ******************************************************************************/
 
-@Version("3.0.0")
+@Version("3.1.0")
 package com.adobe.cq.commerce.magento.graphql;
 
 import org.osgi.annotation.versioning.Version;

--- a/src/main/java/com/shopify/graphql/support/AbstractQuery.java
+++ b/src/main/java/com/shopify/graphql/support/AbstractQuery.java
@@ -28,6 +28,9 @@ public abstract class AbstractQuery<T extends AbstractQuery> {
     public static final String ALIAS_SUFFIX_SEPARATOR = "__";
     private static final String BAD_ALIAS_SEPARATOR = "-";
     private static final String ALIAS_DELIMITER = ":";
+
+    public static final String CUSTOM_FIELD_LABEL = "_custom_";
+
     protected final StringBuilder _queryBuilder;
     private boolean firstSelection = true;
     private String aliasSuffix = null;
@@ -109,6 +112,40 @@ public abstract class AbstractQuery<T extends AbstractQuery> {
             throw new IllegalArgumentException("Alias must not contain -");
         }
         this.aliasSuffix = aliasSuffix;
+        return (T) this;
+    }
+
+    /**
+     * Adds a custom simple field to the GraphQL query. The adjective "simple" here refers to
+     * a scalar/primitive field like String, Integer, Double, Boolean, or an array of simple fields.
+     * 
+     * @param fieldName The name of the field that will be added to the GraphQL request.
+     * @return The current query builder.
+     */
+    @SuppressWarnings("unchecked")
+    public T addCustomSimpleField(String fieldName) {
+        startField(fieldName + CUSTOM_FIELD_LABEL + ALIAS_DELIMITER + fieldName);
+        return (T) this;
+    }
+
+    /**
+     * Adds a custom object field to the GraphQL query. The term "object" here refers to
+     * a GraphQL object, which means some fields of the custom object must also be defined
+     * in the query.
+     * 
+     * @param fieldName The name of the field that will be added to the GraphQL request.
+     * @param queryDef The definition of the requested sub-fields of the object.
+     * @return The current query builder.
+     */
+    @SuppressWarnings("unchecked")
+    public T addCustomObjectField(String fieldName, CustomFieldQueryDefinition queryDef) {
+        // startField("__typename");
+        startField(fieldName + CUSTOM_FIELD_LABEL + ALIAS_DELIMITER + fieldName);
+
+        _queryBuilder.append('{');
+        queryDef.define(new CustomFieldQuery(_queryBuilder));
+        _queryBuilder.append('}');
+
         return (T) this;
     }
 }

--- a/src/main/java/com/shopify/graphql/support/AbstractQuery.java
+++ b/src/main/java/com/shopify/graphql/support/AbstractQuery.java
@@ -117,7 +117,7 @@ public abstract class AbstractQuery<T extends AbstractQuery> {
 
     /**
      * Adds a custom simple field to the GraphQL query. The adjective "simple" here refers to
-     * a scalar/primitive field like String, Integer, Double, Boolean, or an array of simple fields.
+     * a scalar/primitive field like String, Integer, Double, Boolean, or an array of fields.
      * 
      * @param fieldName The name of the field that will be added to the GraphQL request.
      * @return The current query builder.

--- a/src/main/java/com/shopify/graphql/support/AbstractQuery.java
+++ b/src/main/java/com/shopify/graphql/support/AbstractQuery.java
@@ -1,5 +1,6 @@
 /**
  * Copyright 2015 Shopify
+ * Copyright 2019 Adobe
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/main/java/com/shopify/graphql/support/AbstractQuery.java
+++ b/src/main/java/com/shopify/graphql/support/AbstractQuery.java
@@ -139,7 +139,6 @@ public abstract class AbstractQuery<T extends AbstractQuery> {
      */
     @SuppressWarnings("unchecked")
     public T addCustomObjectField(String fieldName, CustomFieldQueryDefinition queryDef) {
-        // startField("__typename");
         startField(fieldName + CUSTOM_FIELD_LABEL + ALIAS_DELIMITER + fieldName);
 
         _queryBuilder.append('{');

--- a/src/main/java/com/shopify/graphql/support/AbstractResponse.java
+++ b/src/main/java/com/shopify/graphql/support/AbstractResponse.java
@@ -163,12 +163,12 @@ public abstract class AbstractResponse<T extends AbstractResponse> implements Se
      * @throws SchemaViolationError If the field name does not contain the <code>_custom_</code> suffix.
      */
     protected void readCustomField(String fieldName, JsonElement element) throws SchemaViolationError {
-        int end = fieldName.indexOf(AbstractQuery.CUSTOM_FIELD_LABEL);
-        if (end > 0) {
-            responseData.put(fieldName.substring(0, end), element);
-        } else {
+        if (!fieldName.endsWith(AbstractQuery.CUSTOM_FIELD_LABEL)) {
             throw new SchemaViolationError(this, fieldName, element);
         }
+
+        int end = fieldName.lastIndexOf(AbstractQuery.CUSTOM_FIELD_LABEL);
+        responseData.put(fieldName.substring(0, end), element);
     }
 
     protected String getFieldName(String key) {

--- a/src/main/java/com/shopify/graphql/support/AbstractResponse.java
+++ b/src/main/java/com/shopify/graphql/support/AbstractResponse.java
@@ -1,5 +1,6 @@
 /**
  * Copyright 2015 Shopify
+ * Copyright 2019 Adobe
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/main/java/com/shopify/graphql/support/CustomFieldInterface.java
+++ b/src/main/java/com/shopify/graphql/support/CustomFieldInterface.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.shopify.graphql.support;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+
+/**
+ * In order to allow custom fields from being "gettable" via java interface classes, this class
+ * defines all the getter methods for custom fields. Note that all these methods are already implemented in
+ * {@link AbstractResponse} so they immediately available to all interfaces.
+ */
+public interface CustomFieldInterface {
+
+    /**
+     * Gets a field as a raw object.
+     * 
+     * @param field The name of the field.
+     * @return The raw object.
+     */
+    public default Object get(String field) {
+        return null;
+    }
+
+    /**
+     * Tries to deserialise and return the given JSON field as a String. The field itself is expected
+     * to be stored in the object data as a {@link JsonElement}, which is the case for custom simple fields.
+     * 
+     * @param field The name of the field.
+     * @return The value of the field.
+     */
+    public default String getAsString(String field) throws SchemaViolationError {
+        return null;
+    }
+
+    /**
+     * Tries to deserialise and return the given JSON field as an Integer. The field itself is expected
+     * to be stored in the object data as a {@link JsonElement}, which is the case for custom simple fields.
+     * 
+     * @param field The name of the field.
+     * @return The value of the field.
+     */
+    public default Integer getAsInteger(String field) throws SchemaViolationError {
+        return null;
+    }
+
+    /**
+     * Tries to deserialise and return the given JSON field as a Double. The field itself is expected
+     * to be stored in the object data as a {@link JsonElement}, which is the case for custom simple fields.
+     * 
+     * @param field The name of the field.
+     * @return The value of the field.
+     */
+    public default Double getAsDouble(String field) throws SchemaViolationError {
+        return null;
+    }
+
+    /**
+     * Tries to deserialise and return the given JSON field as a Boolean. The field itself is expected
+     * to be stored in the object data as a {@link JsonElement}, which is the case for custom simple fields.
+     * 
+     * @param field The name of the field.
+     * @return The value of the field.
+     */
+    public default Boolean getAsBoolean(String field) throws SchemaViolationError {
+        return null;
+    }
+
+    /**
+     * Tries to deserialise and return the given JSON field as an Array. The field itself is expected
+     * to be stored in the object data as a {@link JsonElement}, which is the case for custom simple fields.
+     * 
+     * @param field The name of the field.
+     * @return The value of the field.
+     */
+    public default JsonArray getAsArray(String field) throws SchemaViolationError {
+        return null;
+    }
+}

--- a/src/main/java/com/shopify/graphql/support/CustomFieldInterface.java
+++ b/src/main/java/com/shopify/graphql/support/CustomFieldInterface.java
@@ -1,16 +1,23 @@
-/*******************************************************************************
- *
- *    Copyright 2019 Adobe. All rights reserved.
- *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License. You may obtain a copy
- *    of the License at http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software distributed under
- *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
- *    OF ANY KIND, either express or implied. See the License for the specific language
- *    governing permissions and limitations under the License.
- *
- ******************************************************************************/
+/**
+ * Copyright 2019 Adobe
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software
+ * is furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 
 package com.shopify.graphql.support;
 

--- a/src/main/java/com/shopify/graphql/support/CustomFieldInterface.java
+++ b/src/main/java/com/shopify/graphql/support/CustomFieldInterface.java
@@ -20,7 +20,7 @@ import com.google.gson.JsonElement;
 /**
  * In order to allow custom fields from being "gettable" via java interface classes, this class
  * defines all the getter methods for custom fields. Note that all these methods are already implemented in
- * {@link AbstractResponse} so they immediately available to all interfaces.
+ * {@link AbstractResponse} so they are immediately available to all interfaces.
  */
 public interface CustomFieldInterface {
 

--- a/src/main/java/com/shopify/graphql/support/CustomFieldQuery.java
+++ b/src/main/java/com/shopify/graphql/support/CustomFieldQuery.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.shopify.graphql.support;
+
+public class CustomFieldQuery extends AbstractQuery<CustomFieldQuery> {
+
+    public CustomFieldQuery(StringBuilder _queryBuilder) {
+        super(_queryBuilder);
+    }
+
+    /**
+     * Adds a standard "non-custom" field to the query. This method is typically used to specify
+     * the fields of a custom object field that has an existing GraphQL type that can already be
+     * parsed by the library.
+     * 
+     * @param fieldName
+     * @return The current query builder.
+     */
+    public CustomFieldQuery addField(String fieldName) {
+        startField(fieldName);
+        return this;
+    }
+}

--- a/src/main/java/com/shopify/graphql/support/CustomFieldQuery.java
+++ b/src/main/java/com/shopify/graphql/support/CustomFieldQuery.java
@@ -1,16 +1,23 @@
-/*******************************************************************************
- *
- *    Copyright 2019 Adobe. All rights reserved.
- *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License. You may obtain a copy
- *    of the License at http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software distributed under
- *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
- *    OF ANY KIND, either express or implied. See the License for the specific language
- *    governing permissions and limitations under the License.
- *
- ******************************************************************************/
+/**
+ * Copyright 2019 Adobe
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software
+ * is furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 
 package com.shopify.graphql.support;
 

--- a/src/main/java/com/shopify/graphql/support/CustomFieldQueryDefinition.java
+++ b/src/main/java/com/shopify/graphql/support/CustomFieldQueryDefinition.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ *
+ *    Copyright 2019 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.shopify.graphql.support;
+
+public interface CustomFieldQueryDefinition {
+    void define(CustomFieldQuery _queryBuilder);
+}

--- a/src/main/java/com/shopify/graphql/support/CustomFieldQueryDefinition.java
+++ b/src/main/java/com/shopify/graphql/support/CustomFieldQueryDefinition.java
@@ -1,16 +1,23 @@
-/*******************************************************************************
- *
- *    Copyright 2019 Adobe. All rights reserved.
- *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License. You may obtain a copy
- *    of the License at http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software distributed under
- *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
- *    OF ANY KIND, either express or implied. See the License for the specific language
- *    governing permissions and limitations under the License.
- *
- ******************************************************************************/
+/**
+ * Copyright 2019 Adobe
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software
+ * is furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 
 package com.shopify.graphql.support;
 

--- a/src/main/java/com/shopify/graphql/support/package-info.java
+++ b/src/main/java/com/shopify/graphql/support/package-info.java
@@ -12,7 +12,7 @@
  *
  ******************************************************************************/
 
-@Version("1.0.0")
+@Version("1.1.0")
 package com.shopify.graphql.support;
 
 import org.osgi.annotation.versioning.Version;

--- a/src/test/java/com/adobe/cq/commerce/magento/graphql/QueryBuilderTest.java
+++ b/src/test/java/com/adobe/cq/commerce/magento/graphql/QueryBuilderTest.java
@@ -27,7 +27,9 @@ import com.adobe.cq.commerce.magento.graphql.gson.MutationDeserializer;
 import com.adobe.cq.commerce.magento.graphql.gson.QueryDeserializer;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
 import com.shopify.graphql.support.AbstractQuery;
+import com.shopify.graphql.support.SchemaViolationError;
 
 public class QueryBuilderTest {
 
@@ -115,6 +117,15 @@ public class QueryBuilderTest {
         Assert.assertEquals(2, categoryTree.getId().intValue());
         Assert.assertEquals("Default Category", categoryTree.getName());
         Assert.assertEquals(1, categoryTree.getChildren().size());
+    }
+
+    @Test(expected = SchemaViolationError.class)
+    public void testSchemaViolationError() throws Exception {
+        String jsonResponse = getResource("responses/root-category-with-unknown-field.json");
+
+        // Triggers a SchemaViolationError
+        // (we don't use QueryDeserializer.getGson().fromJson() because it would trigger a JsonParseException)
+        new Query(new JsonParser().parse(jsonResponse).getAsJsonObject());
     }
 
     @Test

--- a/src/test/resources/queries/category-with-custom-field.txt
+++ b/src/test/resources/queries/category-with-custom-field.txt
@@ -1,0 +1,1 @@
+{category(id:3){id,name,mystring_custom_:mystring,myinteger_custom_:myinteger,mydouble_custom_:mydouble,myboolean_custom_:myboolean,myarray_custom_:myarray}}

--- a/src/test/resources/queries/product-with-custom-fields.txt
+++ b/src/test/resources/queries/product-with-custom-fields.txt
@@ -1,0 +1,1 @@
+{products(search:"short",currentPage:1){items{__typename,sku,erin_recommends_custom_:erin_recommends,climate_custom_:climate,replacement_product_custom_:replacement_product{__typename,sku,name,weight_custom_:weight},crosssell_products_custom_:crosssell_products{__typename,sku,name}}}}

--- a/src/test/resources/responses/category-with-custom-field.json
+++ b/src/test/resources/responses/category-with-custom-field.json
@@ -1,0 +1,11 @@
+{
+  "category": {
+    "id": 3,
+    "name": "Equipment",
+    "mystring_custom_": "somevalue",
+    "myinteger_custom_": 42,
+    "mydouble_custom_": 4.2,
+    "myboolean_custom_": true,
+    "myarray_custom_": ["a", "b"]
+  }
+}

--- a/src/test/resources/responses/product-with-custom-fields.json
+++ b/src/test/resources/responses/product-with-custom-fields.json
@@ -1,0 +1,40 @@
+{
+   "products": {
+    "items": [
+      {
+        "__typename": "ConfigurableProduct",
+        "sku": "MSH12",
+        "erin_recommends_custom_": 0,
+        "climate_custom_": "205,212,209",
+        "crosssell_products_custom_": [
+          {
+            "__typename": "SimpleProduct",
+            "sku": "24-UG06",
+            "name": "Affirm Water Bottle"
+          },
+          {
+            "__typename": "SimpleProduct",
+            "sku": "24-UG04",
+            "name": "Zing Jump Rope"
+          },
+          {
+            "__typename": "SimpleProduct",
+            "sku": "24-UG01",
+            "name": "Quest Lumaflex&trade; Band"
+          },
+          {
+            "__typename": "SimpleProduct",
+            "sku": "24-WG080",
+            "name": "Sprite Yoga Companion Kit"
+          }
+        ],
+        "replacement_product_custom_": {
+          "__typename": "ConfigurableProduct",
+          "sku": "MSH12-old",
+          "name": "Zing Jump Rope",
+          "weight_custom_": 42
+        }
+      }
+    ]
+  }
+}

--- a/src/test/resources/responses/root-category-with-unknown-field.json
+++ b/src/test/resources/responses/root-category-with-unknown-field.json
@@ -1,0 +1,5 @@
+{
+  "category": {
+    "unknown": "Unknown field, will trigger a SchemaViolationError"
+  }
+}


### PR DESCRIPTION
- added the possibility to set and read custom fields in GraphQL requests/responses

## How Has This Been Tested?

Added unit tests.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
