### PR TITLE
CIF-1721: Added interface fragments on interfaces

### DIFF
--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableProductInterfaceQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/CustomizableProductInterfaceQuery.java
@@ -87,6 +87,20 @@ public class CustomizableProductInterfaceQuery extends AbstractQuery<Customizabl
         return this;
     }
 
+    public CustomizableProductInterfaceQuery onPhysicalProductInterface(PhysicalProductInterfaceQueryDefinition queryDef) {
+        startInlineFragment("PhysicalProductInterface");
+        queryDef.define(new PhysicalProductInterfaceQuery(_queryBuilder));
+        _queryBuilder.append('}');
+        return this;
+    }
+
+    public CustomizableProductInterfaceQuery onProductInterface(ProductInterfaceQueryDefinition queryDef) {
+        startInlineFragment("ProductInterface");
+        queryDef.define(new ProductInterfaceQuery(_queryBuilder));
+        _queryBuilder.append('}');
+        return this;
+    }
+
     /**
      * Creates a GraphQL "named" fragment with the specified query type definition.
      * The generics nature of fragments ensures that a fragment can only be used at the right place in the GraphQL request.

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/LayerFilterItemInterfaceQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/LayerFilterItemInterfaceQuery.java
@@ -79,6 +79,13 @@ public class LayerFilterItemInterfaceQuery extends AbstractQuery<LayerFilterItem
         return this;
     }
 
+    public LayerFilterItemInterfaceQuery onSwatchLayerFilterItemInterface(SwatchLayerFilterItemInterfaceQueryDefinition queryDef) {
+        startInlineFragment("SwatchLayerFilterItemInterface");
+        queryDef.define(new SwatchLayerFilterItemInterfaceQuery(_queryBuilder));
+        _queryBuilder.append('}');
+        return this;
+    }
+
     /**
      * Creates a GraphQL "named" fragment with the specified query type definition.
      * The generics nature of fragments ensures that a fragment can only be used at the right place in the GraphQL request.

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/PhysicalProductInterfaceQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/PhysicalProductInterfaceQuery.java
@@ -76,6 +76,20 @@ public class PhysicalProductInterfaceQuery extends AbstractQuery<PhysicalProduct
         return this;
     }
 
+    public PhysicalProductInterfaceQuery onCustomizableProductInterface(CustomizableProductInterfaceQueryDefinition queryDef) {
+        startInlineFragment("CustomizableProductInterface");
+        queryDef.define(new CustomizableProductInterfaceQuery(_queryBuilder));
+        _queryBuilder.append('}');
+        return this;
+    }
+
+    public PhysicalProductInterfaceQuery onProductInterface(ProductInterfaceQueryDefinition queryDef) {
+        startInlineFragment("ProductInterface");
+        queryDef.define(new ProductInterfaceQuery(_queryBuilder));
+        _queryBuilder.append('}');
+        return this;
+    }
+
     /**
      * Creates a GraphQL "named" fragment with the specified query type definition.
      * The generics nature of fragments ensures that a fragment can only be used at the right place in the GraphQL request.

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/ProductInterfaceQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/ProductInterfaceQuery.java
@@ -671,6 +671,20 @@ public class ProductInterfaceQuery extends AbstractQuery<ProductInterfaceQuery> 
         return this;
     }
 
+    public ProductInterfaceQuery onCustomizableProductInterface(CustomizableProductInterfaceQueryDefinition queryDef) {
+        startInlineFragment("CustomizableProductInterface");
+        queryDef.define(new CustomizableProductInterfaceQuery(_queryBuilder));
+        _queryBuilder.append('}');
+        return this;
+    }
+
+    public ProductInterfaceQuery onPhysicalProductInterface(PhysicalProductInterfaceQueryDefinition queryDef) {
+        startInlineFragment("PhysicalProductInterface");
+        queryDef.define(new PhysicalProductInterfaceQuery(_queryBuilder));
+        _queryBuilder.append('}');
+        return this;
+    }
+
     /**
      * Creates a GraphQL "named" fragment with the specified query type definition.
      * The generics nature of fragments ensures that a fragment can only be used at the right place in the GraphQL request.

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/SwatchLayerFilterItemInterfaceQuery.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/SwatchLayerFilterItemInterfaceQuery.java
@@ -49,6 +49,13 @@ public class SwatchLayerFilterItemInterfaceQuery extends AbstractQuery<SwatchLay
         return this;
     }
 
+    public SwatchLayerFilterItemInterfaceQuery onLayerFilterItemInterface(LayerFilterItemInterfaceQueryDefinition queryDef) {
+        startInlineFragment("LayerFilterItemInterface");
+        queryDef.define(new LayerFilterItemInterfaceQuery(_queryBuilder));
+        _queryBuilder.append('}');
+        return this;
+    }
+
     /**
      * Creates a GraphQL "named" fragment with the specified query type definition.
      * The generics nature of fragments ensures that a fragment can only be used at the right place in the GraphQL request.

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/package-info.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/package-info.java
@@ -12,7 +12,7 @@
  *
  ******************************************************************************/
 
-@Version("8.0.0")
+@Version("8.1.0")
 package com.adobe.cq.commerce.magento.graphql;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

add fragments for other interfaces implemented by the possible types of the interface in question.

## Related Issue

CIF-1721

## Motivation and Context

The query builder provides no way to add fragments for other interfaces that are implemented by possible types on an interface query

## How Has This Been Tested?

Manually

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/6639076/98567139-43b20880-22b8-11eb-846c-0983521fee8e.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
