### PR TITLE
CIF-2895 - Extend ProductAttributeFilterInput with custom filters

### DIFF
--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/ProductAttributeFilterInput.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/ProductAttributeFilterInput.java
@@ -15,6 +15,10 @@
 package com.adobe.cq.commerce.magento.graphql;
 
 import java.io.Serializable;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
 
 import com.shopify.graphql.support.Input;
 
@@ -54,6 +58,8 @@ public class ProductAttributeFilterInput implements Serializable {
     private Input<FilterEqualTypeInput> sku = Input.undefined();
 
     private Input<FilterEqualTypeInput> urlKey = Input.undefined();
+
+    private Map<String, Input<Serializable>> customFilters = new HashMap<>();
 
     /**
      * Deprecated: use `category_uid` to filter product by category ID.
@@ -583,9 +589,35 @@ public class ProductAttributeFilterInput implements Serializable {
         return this;
     }
 
+    public ProductAttributeFilterInput setCustomFilter(String name, Serializable filterInput) {
+        this.customFilters.put(name, Input.optional(filterInput));
+        return this;
+    }
+
     public void appendTo(StringBuilder _queryBuilder) {
         String separator = "";
         _queryBuilder.append('{');
+
+        if (!this.customFilters.isEmpty()) {
+            for (Map.Entry<String, Input<Serializable>> entry : customFilters.entrySet()) {
+                _queryBuilder.append(separator);
+                separator = ",";
+                _queryBuilder.append(entry.getKey() + ":");
+
+                Serializable filter = entry.getValue().getValue();
+
+                if (filter != null) {
+                    try {
+                        Method appendTo = filter.getClass().getMethod("appendTo", StringBuilder.class);
+                        appendTo.invoke(filter, _queryBuilder);
+                    } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+                        _queryBuilder.append("null");
+                    }
+                } else {
+                    _queryBuilder.append("null");
+                }
+            }
+        }
 
         if (this.categoryId.isDefined()) {
             _queryBuilder.append(separator);

--- a/src/main/java/com/adobe/cq/commerce/magento/graphql/package-info.java
+++ b/src/main/java/com/adobe/cq/commerce/magento/graphql/package-info.java
@@ -12,7 +12,7 @@
  *
  ******************************************************************************/
 
-@Version("11.0.0")
+@Version("11.1.0")
 package com.adobe.cq.commerce.magento.graphql;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
This is a draft only, to show the E2E usage for adding custom filters.

Please also have a look at:
* https://github.com/adobe/aem-core-cif-components/pull/938
* https://github.com/adobe/aem-cif-guides-venia/pull/300

Changes made:
* Added new `setCustomFilter` method to `ProductAttributeFilterInput` which allows to set a custom filter that is not in the schema.
    * The idea is to extend any input type with this method.
* Added `productAttributeFilterHook` with `replaceProductFilterWith` methods to `AbstractProductRetriever`.
    * Allows to completely replace the `ProductAttributeFilterInput` with something custom.
    * Product identifier is passed as parameter, so this can be used, if required.
* Added example in `MyProductTeaserImpl` to showcase how everything together could look like.